### PR TITLE
Add remaining measurement consumer client functions

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
@@ -40,7 +40,7 @@ suspend fun createParticipationSignature(
   hybridCryptor: HybridCryptor,
   requisition: Requisition,
   privateKeyHandle: PrivateKeyHandle,
-  dataProviderX509: X509Certificate
+  dataProviderCertificate: X509Certificate
 ): SignedData {
   val encryptedRequisitionSpec = requisition.encryptedRequisitionSpec
   val requisitionSpec =
@@ -51,9 +51,10 @@ suspend fun createParticipationSignature(
     hashedEncryptedRequisitionSpec
       .concat(requireNotNull(requisitionSpec.dataProviderListHash))
       .concat(requireNotNull(requisition.measurementSpec.data))
-  val privateKey: PrivateKey = requireNotNull(privateKeyHandle.toJavaPrivateKey(dataProviderX509))
+  val privateKey: PrivateKey =
+    requireNotNull(privateKeyHandle.toJavaPrivateKey(dataProviderCertificate))
   val participationSignature =
-    privateKey.sign(certificate = dataProviderX509, data = requisitionFingerprint)
+    privateKey.sign(certificate = dataProviderCertificate, data = requisitionFingerprint)
   return SignedData.newBuilder()
     .apply {
       data = requisitionFingerprint
@@ -66,11 +67,11 @@ suspend fun createParticipationSignature(
 suspend fun signEncryptionPublicKey(
   encryptionPublicKey: EncryptionPublicKey,
   privateKeyHandle: PrivateKeyHandle,
-  dataProviderX509: X509Certificate
+  dataProviderCertificate: X509Certificate
 ): SignedData {
   return signMessage<EncryptionPublicKey>(
     message = encryptionPublicKey,
     privateKeyHandle = privateKeyHandle,
-    certificate = dataProviderX509
+    certificate = dataProviderCertificate
   )
 }

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
@@ -6,11 +6,13 @@ kt_jvm_library(
     name = "measurementconsumer",
     srcs = ["MeasurementConsumerClient.kt"],
     deps = [
-        "//src/main/kotlin/org/wfanet/measurement/consent/crypto:hashing",
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto:signatures",
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto:utils",
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto/hybridencryption",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:measurement_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:measurement_spec_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:requisition_spec_java_proto",
         "@wfa_common_jvm//imports/java/org/conscrypt",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -34,26 +34,25 @@ import org.wfanet.measurement.consent.crypto.verifySignature
  * to determine the algorithm type of the signature
  */
 suspend fun signRequisitionSpec(
-  requisitionSpec: RequisitionSpec,
-  measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
-  measurementConsumerX509: ByteString
+    requisitionSpec: RequisitionSpec,
+    measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
+    measurementConsumerX509: ByteString
 ): SignedData {
   return signMessage<RequisitionSpec>(
-    message = requisitionSpec,
-    privateKeyHandle = measurementConsumerPrivateKeyHandle,
-    certificate = readCertificate(measurementConsumerX509)
-  )
+      message = requisitionSpec,
+      privateKeyHandle = measurementConsumerPrivateKeyHandle,
+      certificate = readCertificate(measurementConsumerX509))
 }
 
 /**
- * Encrypts the [SignedData] of the requisitionSpec using the specified [HybridCryptor]
- * specified by the [HybridEncryptionMapper].
+ * Encrypts the [SignedData] of the requisitionSpec using the specified [HybridCryptor] specified by
+ * the [HybridEncryptionMapper].
  */
 suspend fun encryptRequisitionSpec(
-  signedRequisitionSpec: SignedData,
-  measurementPublicKey: EncryptionPublicKey,
-  cipherSuite: HybridCipherSuite,
-  hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
+    signedRequisitionSpec: SignedData,
+    measurementPublicKey: EncryptionPublicKey,
+    cipherSuite: HybridCipherSuite,
+    hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
 ): ByteString {
   val hybridCryptor: HybridCryptor = hybridEncryptionMapper(cipherSuite)
   return hybridCryptor.encrypt(measurementPublicKey, signedRequisitionSpec.toByteString())
@@ -64,28 +63,26 @@ suspend fun encryptRequisitionSpec(
  * to determine the algorithm type of the signature
  */
 suspend fun signMeasurementSpec(
-  measurementSpec: MeasurementSpec,
-  measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
-  measurementConsumerX509: ByteString
+    measurementSpec: MeasurementSpec,
+    measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
+    measurementConsumerX509: ByteString
 ): SignedData {
   return signMessage<MeasurementSpec>(
-    message = measurementSpec,
-    privateKeyHandle = measurementConsumerPrivateKeyHandle,
-    certificate = readCertificate(measurementConsumerX509)
-  )
+      message = measurementSpec,
+      privateKeyHandle = measurementConsumerPrivateKeyHandle,
+      certificate = readCertificate(measurementConsumerX509))
 }
 
 /** Signs the measurementConsumer's encryptionPublicKey. */
 suspend fun signEncryptionPublicKey(
-  encryptionPublicKey: EncryptionPublicKey,
-  privateKeyHandle: PrivateKeyHandle,
-  measurementConsumerX509: ByteString
+    encryptionPublicKey: EncryptionPublicKey,
+    privateKeyHandle: PrivateKeyHandle,
+    measurementConsumerX509: ByteString
 ): SignedData {
   return signMessage<EncryptionPublicKey>(
-    message = encryptionPublicKey,
-    privateKeyHandle = privateKeyHandle,
-    certificate = readCertificate(measurementConsumerX509)
-  )
+      message = encryptionPublicKey,
+      privateKeyHandle = privateKeyHandle,
+      certificate = readCertificate(measurementConsumerX509))
 }
 
 /**
@@ -95,12 +92,9 @@ suspend fun signEncryptionPublicKey(
  * 3. TODO: Verify certificate chain for [aggregatorCertificate]
  */
 suspend fun verifyResult(
-  resultSignature: ByteString,
-  measurementResult: MeasurementResult,
-  aggregatorCertificate: X509Certificate
+    resultSignature: ByteString,
+    measurementResult: MeasurementResult,
+    aggregatorCertificate: X509Certificate
 ): Boolean {
-  return aggregatorCertificate.verifySignature(
-    measurementResult.toByteString(),
-    resultSignature
-  )
+  return aggregatorCertificate.verifySignature(measurementResult.toByteString(), resultSignature)
 }

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -34,14 +34,15 @@ import org.wfanet.measurement.consent.crypto.verifySignature
  * to determine the algorithm type of the signature
  */
 suspend fun signRequisitionSpec(
-    requisitionSpec: RequisitionSpec,
-    measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
-    measurementConsumerX509: ByteString
+  requisitionSpec: RequisitionSpec,
+  measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
+  measurementConsumerX509: ByteString
 ): SignedData {
   return signMessage<RequisitionSpec>(
-      message = requisitionSpec,
-      privateKeyHandle = measurementConsumerPrivateKeyHandle,
-      certificate = readCertificate(measurementConsumerX509))
+    message = requisitionSpec,
+    privateKeyHandle = measurementConsumerPrivateKeyHandle,
+    certificate = readCertificate(measurementConsumerX509)
+  )
 }
 
 /**
@@ -49,10 +50,10 @@ suspend fun signRequisitionSpec(
  * the [HybridEncryptionMapper].
  */
 suspend fun encryptRequisitionSpec(
-    signedRequisitionSpec: SignedData,
-    measurementPublicKey: EncryptionPublicKey,
-    cipherSuite: HybridCipherSuite,
-    hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
+  signedRequisitionSpec: SignedData,
+  measurementPublicKey: EncryptionPublicKey,
+  cipherSuite: HybridCipherSuite,
+  hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
 ): ByteString {
   val hybridCryptor: HybridCryptor = hybridEncryptionMapper(cipherSuite)
   return hybridCryptor.encrypt(measurementPublicKey, signedRequisitionSpec.toByteString())
@@ -63,26 +64,28 @@ suspend fun encryptRequisitionSpec(
  * to determine the algorithm type of the signature
  */
 suspend fun signMeasurementSpec(
-    measurementSpec: MeasurementSpec,
-    measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
-    measurementConsumerX509: ByteString
+  measurementSpec: MeasurementSpec,
+  measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
+  measurementConsumerX509: ByteString
 ): SignedData {
   return signMessage<MeasurementSpec>(
-      message = measurementSpec,
-      privateKeyHandle = measurementConsumerPrivateKeyHandle,
-      certificate = readCertificate(measurementConsumerX509))
+    message = measurementSpec,
+    privateKeyHandle = measurementConsumerPrivateKeyHandle,
+    certificate = readCertificate(measurementConsumerX509)
+  )
 }
 
 /** Signs the measurementConsumer's encryptionPublicKey. */
 suspend fun signEncryptionPublicKey(
-    encryptionPublicKey: EncryptionPublicKey,
-    privateKeyHandle: PrivateKeyHandle,
-    measurementConsumerX509: ByteString
+  encryptionPublicKey: EncryptionPublicKey,
+  privateKeyHandle: PrivateKeyHandle,
+  measurementConsumerX509: ByteString
 ): SignedData {
   return signMessage<EncryptionPublicKey>(
-      message = encryptionPublicKey,
-      privateKeyHandle = privateKeyHandle,
-      certificate = readCertificate(measurementConsumerX509))
+    message = encryptionPublicKey,
+    privateKeyHandle = privateKeyHandle,
+    certificate = readCertificate(measurementConsumerX509)
+  )
 }
 
 /**
@@ -92,9 +95,9 @@ suspend fun signEncryptionPublicKey(
  * 3. TODO: Verify certificate chain for [aggregatorCertificate]
  */
 suspend fun verifyResult(
-    resultSignature: ByteString,
-    measurementResult: MeasurementResult,
-    aggregatorCertificate: X509Certificate
+  resultSignature: ByteString,
+  measurementResult: MeasurementResult,
+  aggregatorCertificate: X509Certificate
 ): Boolean {
   return aggregatorCertificate.verifySignature(measurementResult.toByteString(), resultSignature)
 }

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -35,12 +35,12 @@ import org.wfanet.measurement.consent.crypto.verifySignature
 suspend fun signRequisitionSpec(
   requisitionSpec: RequisitionSpec,
   measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
-  measurementConsumerX509: X509Certificate
+  measurementConsumerCertificate: X509Certificate
 ): SignedData {
   return signMessage<RequisitionSpec>(
     message = requisitionSpec,
     privateKeyHandle = measurementConsumerPrivateKeyHandle,
-    certificate = measurementConsumerX509
+    certificate = measurementConsumerCertificate
   )
 }
 
@@ -65,12 +65,12 @@ suspend fun encryptRequisitionSpec(
 suspend fun signMeasurementSpec(
   measurementSpec: MeasurementSpec,
   measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
-  measurementConsumerX509: X509Certificate
+  measurementConsumerCertificate: X509Certificate
 ): SignedData {
   return signMessage<MeasurementSpec>(
     message = measurementSpec,
     privateKeyHandle = measurementConsumerPrivateKeyHandle,
-    certificate = measurementConsumerX509
+    certificate = measurementConsumerCertificate
   )
 }
 
@@ -78,12 +78,12 @@ suspend fun signMeasurementSpec(
 suspend fun signEncryptionPublicKey(
   encryptionPublicKey: EncryptionPublicKey,
   privateKeyHandle: PrivateKeyHandle,
-  measurementConsumerX509: X509Certificate
+  measurementConsumerCertificate: X509Certificate
 ): SignedData {
   return signMessage<EncryptionPublicKey>(
     message = encryptionPublicKey,
     privateKeyHandle = privateKeyHandle,
-    certificate = measurementConsumerX509
+    certificate = measurementConsumerCertificate
   )
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -88,6 +88,22 @@ suspend fun signEncryptionPublicKey(
 }
 
 /**
+ * Decrypts the [encryptedSignedDataResult] of the measurement results using the specified
+ * [HybridCryptor] specified by the [HybridEncryptionMapper].
+ */
+suspend fun decryptResult(
+  encryptedSignedDataResult: ByteString,
+  measurementPrivateKeyHandle: PrivateKeyHandle,
+  cipherSuite: HybridCipherSuite,
+  hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
+): SignedData {
+  val hybridCryptor: HybridCryptor = hybridEncryptionMapper(cipherSuite)
+  return SignedData.parseFrom(
+    hybridCryptor.decrypt(measurementPrivateKeyHandle, encryptedSignedDataResult)
+  )
+}
+
+/**
  * Verify the Result from the Aggregator
  * 1. Verifies the [measurementResult] against the [resultSignature]
  * 2. TODO: Check for replay attacks for [resultSignature]

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -101,3 +101,20 @@ suspend fun verifyResult(
 ): Boolean {
   return aggregatorCertificate.verifySignature(measurementResult.toByteString(), resultSignature)
 }
+
+/**
+ * Verify the EncryptionPublicKey from the Endpoint Data Provider
+ * 1. Verifies the [encryptionPublicKey] against the [encryptionPublicKeySignature]
+ * 2. TODO: Check for replay attacks for [encryptionPublicKeySignature]
+ * 3. TODO: Verify certificate chain for [edpCertificate]
+ */
+suspend fun verifyEncryptionPublicKey(
+  encryptionPublicKeySignature: ByteString,
+  encryptionPublicKey: EncryptionPublicKey,
+  edpCertificate: X509Certificate
+): Boolean {
+  return edpCertificate.verifySignature(
+    encryptionPublicKey.toByteString(),
+    encryptionPublicKeySignature
+  )
+}

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -15,11 +15,65 @@
 package org.wfanet.measurement.consent.client.measurementconsumer
 
 import com.google.protobuf.ByteString
+import java.security.cert.X509Certificate
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
+import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
+import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResult
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec
+import org.wfanet.measurement.api.v2alpha.RequisitionSpec
 import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.common.crypto.readCertificate
+import org.wfanet.measurement.consent.crypto.getHybridCryptorForCipherSuite
+import org.wfanet.measurement.consent.crypto.hybridencryption.HybridCryptor
 import org.wfanet.measurement.consent.crypto.keystore.PrivateKeyHandle
 import org.wfanet.measurement.consent.crypto.signMessage
+import org.wfanet.measurement.consent.crypto.verifySignature
+
+/**
+ * Signs [requisitionSpec] into a [SignedData] ProtoBuf. The [measurementConsumerX509] is required
+ * to determine the algorithm type of the signature
+ */
+suspend fun signRequisitionSpec(
+  requisitionSpec: RequisitionSpec,
+  measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
+  measurementConsumerX509: ByteString
+): SignedData {
+  return signMessage<RequisitionSpec>(
+    message = requisitionSpec,
+    privateKeyHandle = measurementConsumerPrivateKeyHandle,
+    certificate = readCertificate(measurementConsumerX509)
+  )
+}
+
+/**
+ * Encrypts the [SignedData] of the requisitionSpec using the specified [HybridCryptor]
+ * specified by the [HybridEncryptionMapper].
+ */
+suspend fun encryptRequisitionSpec(
+  signedRequisitionSpec: SignedData,
+  measurementPublicKey: EncryptionPublicKey,
+  cipherSuite: HybridCipherSuite,
+  hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
+): ByteString {
+  val hybridCryptor: HybridCryptor = hybridEncryptionMapper(cipherSuite)
+  return hybridCryptor.encrypt(measurementPublicKey, signedRequisitionSpec.toByteString())
+}
+
+/**
+ * Signs [measurementSpec] into a [SignedData] ProtoBuf. The [measurementConsumerX509] is required
+ * to determine the algorithm type of the signature
+ */
+suspend fun signMeasurementSpec(
+  measurementSpec: MeasurementSpec,
+  measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
+  measurementConsumerX509: ByteString
+): SignedData {
+  return signMessage<MeasurementSpec>(
+    message = measurementSpec,
+    privateKeyHandle = measurementConsumerPrivateKeyHandle,
+    certificate = readCertificate(measurementConsumerX509)
+  )
+}
 
 /** Signs the measurementConsumer's encryptionPublicKey. */
 suspend fun signEncryptionPublicKey(
@@ -31,5 +85,22 @@ suspend fun signEncryptionPublicKey(
     message = encryptionPublicKey,
     privateKeyHandle = privateKeyHandle,
     certificate = readCertificate(measurementConsumerX509)
+  )
+}
+
+/**
+ * Verify the Result from the Aggregator
+ * 1. Verifies the [measurementResult] against the [resultSignature]
+ * 2. TODO: Check for replay attacks for [resultSignature]
+ * 3. TODO: Verify certificate chain for [aggregatorCertificate]
+ */
+suspend fun verifyResult(
+  resultSignature: ByteString,
+  measurementResult: MeasurementResult,
+  aggregatorCertificate: X509Certificate
+): Boolean {
+  return aggregatorCertificate.verifySignature(
+    measurementResult.toByteString(),
+    resultSignature
   )
 }

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -22,7 +22,6 @@ import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResul
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec
 import org.wfanet.measurement.api.v2alpha.SignedData
-import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.consent.crypto.getHybridCryptorForCipherSuite
 import org.wfanet.measurement.consent.crypto.hybridencryption.HybridCryptor
 import org.wfanet.measurement.consent.crypto.keystore.PrivateKeyHandle
@@ -36,12 +35,12 @@ import org.wfanet.measurement.consent.crypto.verifySignature
 suspend fun signRequisitionSpec(
   requisitionSpec: RequisitionSpec,
   measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
-  measurementConsumerX509: ByteString
+  measurementConsumerX509: X509Certificate
 ): SignedData {
   return signMessage<RequisitionSpec>(
     message = requisitionSpec,
     privateKeyHandle = measurementConsumerPrivateKeyHandle,
-    certificate = readCertificate(measurementConsumerX509)
+    certificate = measurementConsumerX509
   )
 }
 
@@ -66,12 +65,12 @@ suspend fun encryptRequisitionSpec(
 suspend fun signMeasurementSpec(
   measurementSpec: MeasurementSpec,
   measurementConsumerPrivateKeyHandle: PrivateKeyHandle,
-  measurementConsumerX509: ByteString
+  measurementConsumerX509: X509Certificate
 ): SignedData {
   return signMessage<MeasurementSpec>(
     message = measurementSpec,
     privateKeyHandle = measurementConsumerPrivateKeyHandle,
-    certificate = readCertificate(measurementConsumerX509)
+    certificate = measurementConsumerX509
   )
 }
 
@@ -79,12 +78,12 @@ suspend fun signMeasurementSpec(
 suspend fun signEncryptionPublicKey(
   encryptionPublicKey: EncryptionPublicKey,
   privateKeyHandle: PrivateKeyHandle,
-  measurementConsumerX509: ByteString
+  measurementConsumerX509: X509Certificate
 ): SignedData {
   return signMessage<EncryptionPublicKey>(
     message = encryptionPublicKey,
     privateKeyHandle = privateKeyHandle,
-    certificate = readCertificate(measurementConsumerX509)
+    certificate = measurementConsumerX509
   )
 }
 

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
@@ -78,7 +78,7 @@ class DataProviderClientTest {
         hybridCryptor = hybridCryptor,
         requisition = requisition,
         privateKeyHandle = privateKeyHandle,
-        dataProviderX509 = DATA_PROVIDER_X509
+        dataProviderCertificate = DATA_PROVIDER_X509
       )
     assertThat(Base64.getEncoder().encodeToString(dataProviderParticipation.data.toByteArray()))
       .isEqualTo(

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
@@ -78,7 +78,7 @@ class DataProviderClientTest {
         hybridCryptor = hybridCryptor,
         requisition = requisition,
         privateKeyHandle = privateKeyHandle,
-        dataProviderX509 = ByteString.copyFrom(DATA_PROVIDER_X509.getEncoded())
+        dataProviderX509 = DATA_PROVIDER_X509
       )
     assertThat(Base64.getEncoder().encodeToString(dataProviderParticipation.data.toByteArray()))
       .isEqualTo(

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "MeasurementConsumerClientTest",
+    srcs = ["MeasurementConsumerClientTest.kt"],
+    test_class = "org.wfanet.measurement.consent.client.measurementconsumer.MeasurementConsumerClientTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer",
+        "//src/main/kotlin/org/wfanet/measurement/consent/crypto:signatures",
+        "//src/main/kotlin/org/wfanet/measurement/consent/crypto/hybridencryption",
+        "//src/main/kotlin/org/wfanet/measurement/consent/crypto/hybridencryption/testing",
+        "//src/main/kotlin/org/wfanet/measurement/consent/crypto/keystore",
+        "//src/main/kotlin/org/wfanet/measurement/consent/crypto/testing:cryptotesting",
+        "//src/main/kotlin/org/wfanet/measurement/consent/testing",
+        "//src/main/proto/wfa/measurement/api/v2alpha:certificate_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:crypto_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:measurement_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:measurement_spec_java_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
@@ -18,6 +18,7 @@ kt_jvm_test(
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_java_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_spec_java_proto",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
         "@wfa_common_jvm//imports/java/org/junit",
         "@wfa_common_jvm//imports/kotlin/kotlin/test",
         "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
@@ -5,6 +5,7 @@ kt_jvm_test(
     srcs = ["MeasurementConsumerClientTest.kt"],
     test_class = "org.wfanet.measurement.consent.client.measurementconsumer.MeasurementConsumerClientTest",
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/consent/client/duchy",
         "//src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer",
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto:signatures",
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto/hybridencryption",

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
@@ -18,7 +18,6 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.extensions.proto.ProtoTruth.assertThat as protoAssertThat
 import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
-import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.BeforeClass
@@ -218,7 +217,7 @@ class MeasurementConsumerClientTest {
         aggregatorCertificate = AGG_CERTIFICATE,
       )
     )
-    assertEquals(FAKE_MEASUREMENT_RESULT.reach.value, decryptedResult.reach.value)
+    assertThat(FAKE_MEASUREMENT_RESULT.reach.value).isEqualTo(decryptedResult.reach.value)
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
@@ -59,20 +59,30 @@ val AGG_X509: X509Certificate = readCertificate(DUCHY_AGG_CERT_PEM_FILE)
 const val AGG_PRIVATE_KEY_HANDLE_KEY = "agg1"
 
 class MeasurementConsumerClientTest {
-  @BeforeClass
-  fun setup() = runBlocking {
-    keyStore.storePrivateKeyDer(
-      MC_PRIVATE_KEY_HANDLE_KEY,
-      ByteString.copyFrom(readPrivateKey(MC_1_KEY_FILE, MC_X509.publicKey.algorithm).encoded)
-    )
-    keyStore.storePrivateKeyDer(
-      EDP_PRIVATE_KEY_HANDLE_KEY,
-      ByteString.copyFrom(readPrivateKey(EDP_1_KEY_FILE, EDP_X509.publicKey.algorithm).encoded)
-    )
-    keyStore.storePrivateKeyDer(
-      AGG_PRIVATE_KEY_HANDLE_KEY,
-      ByteString.copyFrom(readPrivateKey(DUCHY_AGG_KEY_FILE, AGG_X509.publicKey.algorithm).encoded)
-    )
+  companion object {
+    @BeforeClass
+    @JvmStatic
+    fun setup(): Unit {
+      runBlocking {
+        keyStore.storePrivateKeyDer(
+          MC_PRIVATE_KEY_HANDLE_KEY,
+          ByteString.copyFrom(readPrivateKey(MC_1_KEY_FILE, MC_X509.publicKey.algorithm).encoded)
+        )
+        keyStore.storePrivateKeyDer(
+          EDP_PRIVATE_KEY_HANDLE_KEY,
+          ByteString.copyFrom(readPrivateKey(EDP_1_KEY_FILE, EDP_X509.publicKey.algorithm).encoded)
+        )
+        keyStore.storePrivateKeyDer(
+          AGG_PRIVATE_KEY_HANDLE_KEY,
+          ByteString.copyFrom(
+            readPrivateKey(
+              DUCHY_AGG_KEY_FILE,
+              AGG_X509.publicKey.algorithm
+            ).encoded
+          )
+        )
+      }
+    }
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
@@ -62,7 +62,7 @@ class MeasurementConsumerClientTest {
   companion object {
     @BeforeClass
     @JvmStatic
-    fun setup(): Unit {
+    fun setup() {
       runBlocking {
         keyStore.storePrivateKeyDer(
           MC_PRIVATE_KEY_HANDLE_KEY,

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
@@ -102,7 +102,7 @@ class MeasurementConsumerClientTest {
       signRequisitionSpec(
         requisitionSpec = aRequisitionSpec,
         measurementConsumerPrivateKeyHandle = privateKeyHandle,
-        measurementConsumerX509 = ByteString.readFrom(MC_1_CERT_PEM_FILE.inputStream()),
+        measurementConsumerX509 = MC_X509,
       )
     assertTrue(MC_X509.verifySignature(signedResult))
   }
@@ -140,7 +140,7 @@ class MeasurementConsumerClientTest {
       signMeasurementSpec(
         measurementSpec = FAKE_MEASUREMENT_SPEC,
         measurementConsumerPrivateKeyHandle = privateKeyHandle,
-        measurementConsumerX509 = ByteString.readFrom(MC_1_CERT_PEM_FILE.inputStream()),
+        measurementConsumerX509 = MC_X509,
       )
     assertTrue(MC_X509.verifySignature(signedMeasurementSpec))
   }
@@ -157,7 +157,7 @@ class MeasurementConsumerClientTest {
       signEncryptionPublicKey(
         encryptionPublicKey = mcEncryptionPublicKey,
         privateKeyHandle = privateKeyHandle,
-        measurementConsumerX509 = ByteString.readFrom(MC_1_CERT_PEM_FILE.inputStream()),
+        measurementConsumerX509 = MC_X509,
       )
     assertTrue(MC_X509.verifySignature(signedEncryptionPublicKey))
   }

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
@@ -1,0 +1,60 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.consent.client.measurementconsumer
+
+import com.google.protobuf.ByteString
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
+import org.wfanet.measurement.api.v2alpha.RequisitionSpec
+import org.wfanet.measurement.common.crypto.readCertificate
+import org.wfanet.measurement.common.crypto.readPrivateKey
+import org.wfanet.measurement.consent.crypto.keystore.testing.InMemoryKeyStore
+import org.wfanet.measurement.consent.crypto.verifySignature
+import org.wfanet.measurement.consent.testing.MC_1_CERT_PEM_FILE
+import org.wfanet.measurement.consent.testing.MC_1_KEY_FILE
+
+class MeasurementConsumerClientTest {
+  @Test
+  fun `measurementConsumer sign requisitionSpec`() = runBlocking {
+    val keyStore = InMemoryKeyStore()
+    val measurementX509: X509Certificate = readCertificate(MC_1_CERT_PEM_FILE)
+    val aRequisitionSpec =
+      RequisitionSpec.newBuilder()
+        .apply {
+          measurementPublicKey = EncryptionPublicKey.newBuilder().apply { publicKeyInfo = ByteString.copyFromUtf8("testPublicKey") }.build().toByteString()
+          dataProviderListHash = ByteString.copyFromUtf8("fooDataProviderListHash")
+        }
+        .build()
+    val mcPrivateKeyHandleKey = "mc key"
+    val mcPrivateKey: PrivateKey =
+      readPrivateKey(MC_1_KEY_FILE, measurementX509.publicKey.algorithm)
+    val mcPrivateKeyHandle =
+      keyStore.storePrivateKeyDer(
+        mcPrivateKeyHandleKey,
+        ByteString.copyFrom(mcPrivateKey.encoded)
+      )
+    val signedResult =
+      signRequisitionSpec(
+        requisitionSpec = aRequisitionSpec,
+        measurementConsumerPrivateKeyHandle = mcPrivateKeyHandle,
+        measurementConsumerX509 = ByteString.readFrom(MC_1_CERT_PEM_FILE.inputStream()),
+      )
+    assertTrue(measurementX509.verifySignature(signedResult))
+  }
+}

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
@@ -45,9 +45,9 @@ private val keyStore = InMemoryKeyStore()
 private val hybridCryptor = ReversingHybridCryptor()
 
 private val FAKE_MEASUREMENT_SPEC =
-    MeasurementSpec.newBuilder()
-        .apply { cipherSuite = HybridCipherSuite.getDefaultInstance() }
-        .build()
+  MeasurementSpec.newBuilder()
+    .apply { cipherSuite = HybridCipherSuite.getDefaultInstance() }
+    .build()
 
 val MC_X509: X509Certificate = readCertificate(MC_1_CERT_PEM_FILE)
 const val MC_PRIVATE_KEY_HANDLE_KEY = "mc1"
@@ -65,16 +65,19 @@ class MeasurementConsumerClientTest {
     fun setup(): Unit {
       runBlocking {
         keyStore.storePrivateKeyDer(
-            MC_PRIVATE_KEY_HANDLE_KEY,
-            ByteString.copyFrom(readPrivateKey(MC_1_KEY_FILE, MC_X509.publicKey.algorithm).encoded))
+          MC_PRIVATE_KEY_HANDLE_KEY,
+          ByteString.copyFrom(readPrivateKey(MC_1_KEY_FILE, MC_X509.publicKey.algorithm).encoded)
+        )
         keyStore.storePrivateKeyDer(
-            EDP_PRIVATE_KEY_HANDLE_KEY,
-            ByteString.copyFrom(
-                readPrivateKey(EDP_1_KEY_FILE, EDP_X509.publicKey.algorithm).encoded))
+          EDP_PRIVATE_KEY_HANDLE_KEY,
+          ByteString.copyFrom(readPrivateKey(EDP_1_KEY_FILE, EDP_X509.publicKey.algorithm).encoded)
+        )
         keyStore.storePrivateKeyDer(
-            AGG_PRIVATE_KEY_HANDLE_KEY,
-            ByteString.copyFrom(
-                readPrivateKey(DUCHY_AGG_KEY_FILE, AGG_X509.publicKey.algorithm).encoded))
+          AGG_PRIVATE_KEY_HANDLE_KEY,
+          ByteString.copyFrom(
+            readPrivateKey(DUCHY_AGG_KEY_FILE, AGG_X509.publicKey.algorithm).encoded
+          )
+        )
       }
     }
   }
@@ -82,24 +85,24 @@ class MeasurementConsumerClientTest {
   @Test
   fun `measurementConsumer sign requisitionSpec`() = runBlocking {
     val aRequisitionSpec =
-        RequisitionSpec.newBuilder()
-            .apply {
-              measurementPublicKey =
-                  EncryptionPublicKey.newBuilder()
-                      .apply { publicKeyInfo = ByteString.copyFromUtf8("testPublicKey") }
-                      .build()
-                      .toByteString()
-              dataProviderListHash = ByteString.copyFromUtf8("testDataProviderListHash")
-            }
-            .build()
+      RequisitionSpec.newBuilder()
+        .apply {
+          measurementPublicKey =
+            EncryptionPublicKey.newBuilder()
+              .apply { publicKeyInfo = ByteString.copyFromUtf8("testPublicKey") }
+              .build()
+              .toByteString()
+          dataProviderListHash = ByteString.copyFromUtf8("testDataProviderListHash")
+        }
+        .build()
     val privateKeyHandle = keyStore.getPrivateKeyHandle(MC_PRIVATE_KEY_HANDLE_KEY)
     requireNotNull(privateKeyHandle)
     val signedResult =
-        signRequisitionSpec(
-            requisitionSpec = aRequisitionSpec,
-            measurementConsumerPrivateKeyHandle = privateKeyHandle,
-            measurementConsumerX509 = ByteString.readFrom(MC_1_CERT_PEM_FILE.inputStream()),
-        )
+      signRequisitionSpec(
+        requisitionSpec = aRequisitionSpec,
+        measurementConsumerPrivateKeyHandle = privateKeyHandle,
+        measurementConsumerX509 = ByteString.readFrom(MC_1_CERT_PEM_FILE.inputStream()),
+      )
     assertTrue(MC_X509.verifySignature(signedResult))
   }
 
@@ -107,24 +110,24 @@ class MeasurementConsumerClientTest {
   fun `measurementConsumer encrypt requisitionSpec`() = runBlocking {
     val measurementPublicKey = EncryptionPublicKey.getDefaultInstance()
     val aSignedRequisitionSpec =
-        SignedData.newBuilder()
-            .apply {
-              data = ByteString.copyFromUtf8("testRequisitionSpec")
-              signature = ByteString.copyFromUtf8("testRequisitionSpecSignature")
-            }
-            .build()
+      SignedData.newBuilder()
+        .apply {
+          data = ByteString.copyFromUtf8("testRequisitionSpec")
+          signature = ByteString.copyFromUtf8("testRequisitionSpecSignature")
+        }
+        .build()
     val encryptedSignedRequisitionSpec =
-        encryptRequisitionSpec(
-            signedRequisitionSpec = aSignedRequisitionSpec,
-            measurementPublicKey = measurementPublicKey,
-            cipherSuite = FAKE_MEASUREMENT_SPEC.cipherSuite,
-            hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite)
+      encryptRequisitionSpec(
+        signedRequisitionSpec = aSignedRequisitionSpec,
+        measurementPublicKey = measurementPublicKey,
+        cipherSuite = FAKE_MEASUREMENT_SPEC.cipherSuite,
+        hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite
+      )
 
     val privateKeyHandle = keyStore.getPrivateKeyHandle(EDP_PRIVATE_KEY_HANDLE_KEY)
     requireNotNull(privateKeyHandle)
     val decryptedSignedRequisitionSpec =
-        SignedData.parseFrom(
-            hybridCryptor.decrypt(privateKeyHandle, encryptedSignedRequisitionSpec))
+      SignedData.parseFrom(hybridCryptor.decrypt(privateKeyHandle, encryptedSignedRequisitionSpec))
     Truth.assertThat(decryptedSignedRequisitionSpec).isEqualTo(aSignedRequisitionSpec)
   }
 
@@ -133,58 +136,58 @@ class MeasurementConsumerClientTest {
     val privateKeyHandle = keyStore.getPrivateKeyHandle(MC_PRIVATE_KEY_HANDLE_KEY)
     requireNotNull(privateKeyHandle)
     val signedMeasurementSpec =
-        signMeasurementSpec(
-            measurementSpec = FAKE_MEASUREMENT_SPEC,
-            measurementConsumerPrivateKeyHandle = privateKeyHandle,
-            measurementConsumerX509 = ByteString.readFrom(MC_1_CERT_PEM_FILE.inputStream()),
-        )
+      signMeasurementSpec(
+        measurementSpec = FAKE_MEASUREMENT_SPEC,
+        measurementConsumerPrivateKeyHandle = privateKeyHandle,
+        measurementConsumerX509 = ByteString.readFrom(MC_1_CERT_PEM_FILE.inputStream()),
+      )
     assertTrue(MC_X509.verifySignature(signedMeasurementSpec))
   }
 
   @Test
   fun `measurementConsumer sign encryptionPublicKey`() = runBlocking {
     val mcEncryptionPublicKey =
-        EncryptionPublicKey.newBuilder()
-            .apply { publicKeyInfo = ByteString.copyFromUtf8("testMCPublicKey") }
-            .build()
+      EncryptionPublicKey.newBuilder()
+        .apply { publicKeyInfo = ByteString.copyFromUtf8("testMCPublicKey") }
+        .build()
     val privateKeyHandle = keyStore.getPrivateKeyHandle(MC_PRIVATE_KEY_HANDLE_KEY)
     requireNotNull(privateKeyHandle)
     val signedEncryptionPublicKey =
-        signEncryptionPublicKey(
-            encryptionPublicKey = mcEncryptionPublicKey,
-            privateKeyHandle = privateKeyHandle,
-            measurementConsumerX509 = ByteString.readFrom(MC_1_CERT_PEM_FILE.inputStream()),
-        )
+      signEncryptionPublicKey(
+        encryptionPublicKey = mcEncryptionPublicKey,
+        privateKeyHandle = privateKeyHandle,
+        measurementConsumerX509 = ByteString.readFrom(MC_1_CERT_PEM_FILE.inputStream()),
+      )
     assertTrue(MC_X509.verifySignature(signedEncryptionPublicKey))
   }
 
   @Test
   fun `measurementConsumer verifies result`() = runBlocking {
     val measurementResult =
-        Measurement.Result.newBuilder()
-            .apply {
-              reach = Measurement.Result.Reach.newBuilder().apply { value = 10 }.build()
-              frequency =
-                  Measurement.Result.Frequency.newBuilder()
-                      .apply {
-                        putAllRelativeFrequencyDistribution(mapOf(1L to 1.0, 2L to 2.0, 3L to 3.0))
-                      }
-                      .build()
-            }
-            .build()
+      Measurement.Result.newBuilder()
+        .apply {
+          reach = Measurement.Result.Reach.newBuilder().apply { value = 10 }.build()
+          frequency =
+            Measurement.Result.Frequency.newBuilder()
+              .apply { putAllRelativeFrequencyDistribution(mapOf(1L to 1.0, 2L to 2.0, 3L to 3.0)) }
+              .build()
+        }
+        .build()
     val privateKeyHandle = keyStore.getPrivateKeyHandle(AGG_PRIVATE_KEY_HANDLE_KEY)
     requireNotNull(privateKeyHandle)
     val signedResult =
-        signMessage<Measurement.Result>(
-            message = measurementResult,
-            privateKeyHandle = privateKeyHandle,
-            certificate = AGG_X509)
+      signMessage<Measurement.Result>(
+        message = measurementResult,
+        privateKeyHandle = privateKeyHandle,
+        certificate = AGG_X509
+      )
 
     assertTrue(
-        verifyResult(
-            resultSignature = signedResult.signature,
-            measurementResult = measurementResult,
-            aggregatorCertificate = AGG_X509,
-        ))
+      verifyResult(
+        resultSignature = signedResult.signature,
+        measurementResult = measurementResult,
+        aggregatorCertificate = AGG_X509,
+      )
+    )
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
@@ -15,7 +15,7 @@
 package org.wfanet.measurement.consent.client.measurementconsumer
 
 import com.google.common.truth.Truth.assertThat
-import com.google.common.truth.extensions.proto.ProtoTruth.assertThat as protoAssertThat
+import com.google.common.truth.extensions.proto.ProtoTruth.assertThat
 import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
 import kotlin.test.assertTrue
@@ -209,7 +209,7 @@ class MeasurementConsumerClientTest {
       )
     val decryptedResult = Measurement.Result.parseFrom(decryptedSignedDataResult.data)
 
-    protoAssertThat(signedResult).isEqualTo(decryptedSignedDataResult)
+    assertThat(signedResult).isEqualTo(decryptedSignedDataResult)
     assertTrue(
       verifyResult(
         resultSignature = decryptedSignedDataResult.signature,


### PR DESCRIPTION
- Add the remaining client functions for measurement consumer
  - Sign RequisitionSpec
  - Encrypt RequisitionSpec
  - Sign MeasurementSpec
  - Verify Result
  - Verify EncryptionPublicKey (EDP)
- Add corresponding unit tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/consent-signaling-client/12)
<!-- Reviewable:end -->
