### PR TITLE
Add support for signing and validating Flows

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,9 +25,9 @@ http_archive(
 # Common JVM for Measurement
 http_archive(
     name = "wfa_common_jvm",
-    sha256 = "063c72f91b6b126d4426f46cdc94ae8a98b828901eb1b6af853e5aa0df6b676c",
-    strip_prefix = "common-jvm-e5de55dabc8685f37ba5eb90a7f4c638185330f2",
-    url = "https://github.com/world-federation-of-advertisers/common-jvm/archive/e5de55dabc8685f37ba5eb90a7f4c638185330f2.tar.gz",
+    sha256 = "99498e90f5854ebc101ead7accc7818463b203cec8cda6b4f0eeee70d45ad67b",
+    strip_prefix = "common-jvm-0.8.0",
+    url = "https://github.com/world-federation-of-advertisers/common-jvm/archive/v0.8.0.tar.gz",
 )
 
 # @com_google_truth_truth

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/storage/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/storage/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+package(default_visibility = ["//visibility:public"])
+
+kt_jvm_library(
+    name = "storage",
+    srcs = ["Storage.kt"],
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/consent/crypto:signatures",
+        "//src/main/kotlin/org/wfanet/measurement/consent/crypto/exception",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/storage:client",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/storage/Storage.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/storage/Storage.kt
@@ -1,0 +1,58 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO: Move this file to common-jvm
+
+package org.wfanet.measurement.consent.client.storage
+
+import com.google.protobuf.ByteString
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import kotlinx.coroutines.flow.Flow
+import org.wfanet.measurement.consent.crypto.signFlow
+import org.wfanet.measurement.consent.crypto.verifySignedFlow
+import org.wfanet.measurement.storage.StorageClient
+import org.wfanet.measurement.storage.StorageClient.Blob
+
+/**
+ * Stub for verified read function. Intended to be used in combination with a the other party's
+ * provided [X509Certificate], this validates that the data in the blob has been generated (or at
+ * least signed as valid) by the other party.
+ *
+ * Note that the validation happens in a separate thread and is non-blocking, but will throw a
+ * terminal error if it fails.
+ */
+suspend fun Blob.verifiedRead(
+  cert: X509Certificate,
+  signature: ByteString,
+  bufferSize: Int
+): Flow<ByteString> {
+  return cert.verifySignedFlow(this.read(bufferSize), signature)
+}
+
+/**
+ * Stub for verified write function. Intended to be used in combination with a provided [PrivateKey]
+ * , this creates a signature in shared storage for the written blob that can be verified by the
+ * other party using a pre-provided [X509Certificate].
+ */
+suspend fun StorageClient.createSignedBlob(
+  blobKey: String,
+  content: Flow<ByteString>,
+  privateKey: PrivateKey,
+  cert: X509Certificate
+): Pair<Blob, ByteString> {
+  val (contentFlow, deferredSig) = privateKey.signFlow(cert, content)
+  val resultBlob = this.createBlob(blobKey = blobKey, content = contentFlow)
+  return resultBlob to deferredSig.await()
+}

--- a/src/main/kotlin/org/wfanet/measurement/consent/crypto/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/crypto/BUILD.bazel
@@ -6,6 +6,7 @@ kt_jvm_library(
     name = "signatures",
     srcs = ["Signatures.kt"],
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/consent/crypto/exception",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_java_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:security_provider",

--- a/src/main/kotlin/org/wfanet/measurement/consent/crypto/Signatures.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/crypto/Signatures.kt
@@ -12,14 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: Move this file to common-jvm
 package org.wfanet.measurement.consent.crypto
 
 import com.google.protobuf.ByteString
 import java.security.PrivateKey
 import java.security.Signature
 import java.security.cert.X509Certificate
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
 import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.common.crypto.jceProvider
+import org.wfanet.measurement.consent.crypto.exception.InvalidSignatureException
 
 /**
  * Signs [data] using this [PrivateKey].
@@ -31,6 +38,28 @@ fun PrivateKey.sign(certificate: X509Certificate, data: ByteString): ByteString 
   signer.initSign(this)
   signer.update(data.asReadOnlyByteBuffer())
   return ByteString.copyFrom(signer.sign())
+}
+
+/**
+ * Signs [data] using this [PrivateKey]. Takes in a [Flow<ByteString>] for signing streaming data.
+ *
+ * Note that the deferred output (the signature) will only be ready when the Flow has been fully
+ * collected.
+ *
+ * @param certificate the [X509Certificate] that can be used to verify the signature
+ */
+fun PrivateKey.signFlow(
+  certificate: X509Certificate,
+  data: Flow<ByteString>
+): Pair<Flow<ByteString>, Deferred<ByteString>> {
+  val signer = Signature.getInstance(certificate.sigAlgName, jceProvider)
+  val deferredSig = CompletableDeferred<ByteString>()
+  signer.initSign(this)
+  val outFlow =
+    data.onEach { signer.update(it.asReadOnlyByteBuffer()) }.onCompletion {
+      deferredSig.complete(ByteString.copyFrom(signer.sign()))
+    }
+  return outFlow to deferredSig
 }
 
 /**
@@ -49,4 +78,25 @@ fun X509Certificate.verifySignature(data: ByteString, signature: ByteString): Bo
  */
 fun X509Certificate.verifySignature(signedData: SignedData): Boolean {
   return verifySignature(signedData.data, signedData.signature)
+}
+
+/**
+ * Returns a flow containing the original values of Flow [data] and verifies that the [signature]
+ * for [data] was signed by the entity represented by this [X509Certificate].
+ *
+ * The output is the downstream Flow of [data]. If [data] is found to not match [signature] upon
+ * collecting the flow, the flow will throw an [InvalidSignatureException].
+ */
+fun X509Certificate.verifySignedFlow(
+  data: Flow<ByteString>,
+  signature: ByteString,
+): Flow<ByteString> {
+  val verifier = Signature.getInstance(this.sigAlgName, jceProvider)
+
+  verifier.initVerify(this)
+  return data.onEach { verifier.update(it.asReadOnlyByteBuffer()) }.onCompletion {
+    if (it == null && !verifier.verify(signature.toByteArray())) {
+      throw InvalidSignatureException("Signature is invalid")
+    }
+  }
 }

--- a/src/main/kotlin/org/wfanet/measurement/consent/crypto/exception/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/crypto/exception/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+package(default_visibility = ["//visibility:public"])
+
+kt_jvm_library(
+    name = "exception",
+    srcs = glob(["*.kt"]),
+    deps = [
+    ],
+)

--- a/src/main/kotlin/org/wfanet/measurement/consent/crypto/exception/InvalidSignatureException.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/crypto/exception/InvalidSignatureException.kt
@@ -1,0 +1,22 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO: Move this file to common-jvm
+package org.wfanet.measurement.consent.crypto.exception
+
+/**
+ * Indicates that there is a problem matching data to a signature. Either the signature is invalid
+ * for the data or can't be found at all.
+ */
+class InvalidSignatureException(message: String) : Exception(message)

--- a/src/test/kotlin/org/wfanet/measurement/consent/crypto/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/consent/crypto/BUILD.bazel
@@ -6,10 +6,11 @@ kt_jvm_test(
     test_class = "org.wfanet.measurement.consent.crypto.SignaturesTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto:signatures",
-        "//src/main/kotlin/org/wfanet/measurement/consent/testing",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/org/junit",
         "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:security_provider",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/testing",
     ],


### PR DESCRIPTION
Used in panel exchange storage to sign and validate blob data. The storage
  extensions added in client allow for public access to the new signature
  functions.

- The signature returns a pair and requires the flow to be completed for the
  signature to be generated

- The validate step throws a custom DataFailsSignatureValidation if the Flow is
  invalid.

- Adds public helper extension functions in storage/Storage.kt that support
  signature matching (Blob.verifiedRead and StorageClient.createSignedBlob).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/consent-signaling-client/16)
<!-- Reviewable:end -->
