### PR TITLE
Add method for verifying double signature of exchange step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 # IntelliJ projects.
 .idea/
 *.iml
+
+# VIM swap files
+**/*.swp

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -165,7 +165,7 @@ switched_rules_by_language(
 # Measurement proto.
 http_archive(
     name = "wfa_measurement_proto",
-    sha256 = "12f231fe7c8f75e3170ee9c6e308d355eccc354ed60ef4505f6f537812652626",
-    strip_prefix = "cross-media-measurement-api-584b40ca7b4275d194cc4cedfb877c05ec5ab24e",
-    url = "https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/584b40ca7b4275d194cc4cedfb877c05ec5ab24e.tar.gz",
+    sha256 = "9a4f5054f4a2b4d03ad8398436e04781f39b20f8ad13da15cbc80f21d69b888f",
+    strip_prefix = "cross-media-measurement-api-c742b249dcdcb1731899b2a8d61e9fcf1b597ca7",
+    url = "https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/c742b249dcdcb1731899b2a8d61e9fcf1b597ca7.tar.gz",
 )

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto:utils",
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto/hybridencryption",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_java_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_spec_java_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:requisition_java_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:requisition_spec_java_proto",

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
@@ -19,6 +19,7 @@ import java.security.PrivateKey
 import java.security.cert.X509Certificate
 import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
+import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.Requisition
@@ -30,6 +31,7 @@ import org.wfanet.measurement.consent.crypto.hybridencryption.HybridCryptor
 import org.wfanet.measurement.consent.crypto.keystore.PrivateKeyHandle
 import org.wfanet.measurement.consent.crypto.sign
 import org.wfanet.measurement.consent.crypto.signMessage
+import org.wfanet.measurement.consent.crypto.verifyExchangeStepSignatures as verifyExchangeStepSignaturesCommon
 import org.wfanet.measurement.consent.crypto.verifySignature
 
 /**
@@ -150,3 +152,18 @@ fun verifyElGamalPublicKey(
     elGamalPublicKeySignature
   )
 }
+
+/**
+ * Verifies that the [signedExchangeWorkflow] was signed by both the entities represented by
+ * [modelProviderCertificate] and [dataProviderCertificate]
+ */
+fun verifyExchangeStepSignatures(
+  signedExchangeWorkflow: ExchangeStep.SignedExchangeWorkflow,
+  modelProviderCertificate: X509Certificate,
+  dataProviderCertificate: X509Certificate,
+): Boolean =
+  verifyExchangeStepSignaturesCommon(
+    signedExchangeWorkflow,
+    modelProviderCertificate,
+    dataProviderCertificate,
+  )

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
@@ -11,6 +11,7 @@ kt_jvm_library(
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto:utils",
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto/hybridencryption",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_java_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_java_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_spec_java_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:requisition_spec_java_proto",

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -17,6 +17,7 @@ package org.wfanet.measurement.consent.client.measurementconsumer
 import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
+import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResult
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
@@ -27,6 +28,7 @@ import org.wfanet.measurement.consent.crypto.hashSha256
 import org.wfanet.measurement.consent.crypto.hybridencryption.HybridCryptor
 import org.wfanet.measurement.consent.crypto.keystore.PrivateKeyHandle
 import org.wfanet.measurement.consent.crypto.signMessage
+import org.wfanet.measurement.consent.crypto.verifyExchangeStepSignatures as verifyExchangeStepSignaturesCommon
 import org.wfanet.measurement.consent.crypto.verifySignature
 
 /** Create a SHA256 hash of the serialized [dataProviderList] using the [dataProviderListSalt]. */
@@ -142,3 +144,18 @@ fun verifyEncryptionPublicKey(
     encryptionPublicKeySignature
   )
 }
+
+/**
+ * Verifies that the [signedExchangeWorkflow] was signed by both the entities represented by
+ * [modelProviderCertificate] and [dataProviderCertificate]
+ */
+fun verifyExchangeStepSignatures(
+  signedExchangeWorkflow: ExchangeStep.SignedExchangeWorkflow,
+  modelProviderCertificate: X509Certificate,
+  dataProviderCertificate: X509Certificate,
+): Boolean =
+  verifyExchangeStepSignaturesCommon(
+    signedExchangeWorkflow,
+    modelProviderCertificate,
+    dataProviderCertificate,
+  )

--- a/src/main/kotlin/org/wfanet/measurement/consent/crypto/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/crypto/BUILD.bazel
@@ -8,6 +8,7 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto/exception",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_java_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_java_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:security_provider",
     ],

--- a/src/main/kotlin/org/wfanet/measurement/consent/crypto/Utils.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/crypto/Utils.kt
@@ -17,6 +17,7 @@ package org.wfanet.measurement.consent.crypto
 import com.google.protobuf.Message
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
+import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.consent.crypto.hybridencryption.EciesCryptor
@@ -49,4 +50,27 @@ fun getHybridCryptorForCipherSuite(cipherSuite: HybridCipherSuite): HybridCrypto
     ) -> EciesCryptor()
     else -> throw IllegalArgumentException("Unsupported cipher suite")
   }
+}
+
+/**
+ * Verifies that the [signedExchangeWorkflow] was signed by both the entities represented by
+ * [modelProviderCertificate] and [dataProviderCertificate]
+ */
+fun verifyExchangeStepSignatures(
+  signedExchangeWorkflow: ExchangeStep.SignedExchangeWorkflow,
+  modelProviderCertificate: X509Certificate,
+  dataProviderCertificate: X509Certificate,
+): Boolean {
+  val signedData = signedExchangeWorkflow.serializedExchangeWorkflow
+  val hasModelProviderSignature =
+    modelProviderCertificate.verifySignature(
+      signedData,
+      signedExchangeWorkflow.modelProviderSignature
+    )
+  val hasDataProviderSignature =
+    dataProviderCertificate.verifySignature(
+      signedData,
+      signedExchangeWorkflow.dataProviderSignature
+    )
+  return hasModelProviderSignature && hasDataProviderSignature
 }

--- a/src/main/kotlin/org/wfanet/measurement/consent/testing/AbstractExchangeStepSignaturesTest.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/testing/AbstractExchangeStepSignaturesTest.kt
@@ -1,0 +1,89 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.consent.testing
+
+import com.google.protobuf.ByteString
+import java.security.cert.X509Certificate
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+import org.wfanet.measurement.api.v2alpha.ExchangeStep
+import org.wfanet.measurement.common.crypto.readCertificate
+import org.wfanet.measurement.common.crypto.readPrivateKey
+import org.wfanet.measurement.common.crypto.testing.KEY_ALGORITHM
+import org.wfanet.measurement.consent.crypto.sign
+
+private val DATA = ByteString.copyFromUtf8("I am some data to be double signed")
+private val RANDOM_SIGNATURE = ByteString.copyFromUtf8("some random certificate signature")
+
+typealias verifyExchangeStepSignaturesFunction =
+  (ExchangeStep.SignedExchangeWorkflow, X509Certificate, X509Certificate) -> Boolean
+
+abstract class AbstractExchangeStepSignaturesFunctionTest {
+  abstract val verifyExchangeStepSignatures: verifyExchangeStepSignaturesFunction
+
+  @Test
+  fun `verifyExchangeStepSignatures returns false for having only an MC valid signature`() {
+    val mcPrivateKey = readPrivateKey(MC_1_KEY_FILE, KEY_ALGORITHM)
+    val mcCertificate: X509Certificate = readCertificate(MC_1_CERT_PEM_FILE)
+    val edpCertificate: X509Certificate = readCertificate(EDP_1_CERT_PEM_FILE)
+    val mcSignature = mcPrivateKey.sign(mcCertificate, DATA)
+    val exchangeWorkflow =
+      ExchangeStep.SignedExchangeWorkflow.newBuilder()
+        .apply {
+          serializedExchangeWorkflow = DATA
+          modelProviderSignature = mcSignature
+          dataProviderSignature = RANDOM_SIGNATURE
+        }
+        .build()
+    assertFalse(verifyExchangeStepSignatures(exchangeWorkflow, mcCertificate, edpCertificate))
+  }
+
+  @Test
+  fun `verifyExchangeStepSignatures returns false for having only an EDP valid signature`() {
+    val edpPrivateKey = readPrivateKey(EDP_1_KEY_FILE, KEY_ALGORITHM)
+    val edpCertificate: X509Certificate = readCertificate(EDP_1_CERT_PEM_FILE)
+    val mcCertificate: X509Certificate = readCertificate(MC_1_CERT_PEM_FILE)
+    val edpSignature = edpPrivateKey.sign(edpCertificate, DATA)
+    val exchangeWorkflow =
+      ExchangeStep.SignedExchangeWorkflow.newBuilder()
+        .apply {
+          serializedExchangeWorkflow = DATA
+          modelProviderSignature = RANDOM_SIGNATURE
+          dataProviderSignature = edpSignature
+        }
+        .build()
+    assertFalse(verifyExchangeStepSignatures(exchangeWorkflow, mcCertificate, edpCertificate))
+  }
+
+  @Test
+  fun `verifyExchangeStepSignatures returns true when both signatures are valid`() {
+    val mcPrivateKey = readPrivateKey(MC_1_KEY_FILE, KEY_ALGORITHM)
+    val mcCertificate: X509Certificate = readCertificate(MC_1_CERT_PEM_FILE)
+    val edpPrivateKey = readPrivateKey(EDP_1_KEY_FILE, KEY_ALGORITHM)
+    val edpCertificate: X509Certificate = readCertificate(EDP_1_CERT_PEM_FILE)
+    val mcSignature = mcPrivateKey.sign(mcCertificate, DATA)
+    val edpSignature = edpPrivateKey.sign(edpCertificate, DATA)
+    val exchangeWorkflow =
+      ExchangeStep.SignedExchangeWorkflow.newBuilder()
+        .apply {
+          serializedExchangeWorkflow = DATA
+          modelProviderSignature = mcSignature
+          dataProviderSignature = edpSignature
+        }
+        .build()
+    assertTrue(verifyExchangeStepSignatures(exchangeWorkflow, mcCertificate, edpCertificate))
+  }
+}

--- a/src/main/kotlin/org/wfanet/measurement/consent/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/testing/BUILD.bazel
@@ -125,6 +125,11 @@ kt_jvm_library(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/testing/testdata:static_certs",
     ],
     deps = [
-        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
+        "//src/main/kotlin/org/wfanet/measurement/consent/crypto:signatures",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_java_proto",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:security_provider",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/testing",
     ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/consent/testing/CertificateTesting.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/testing/CertificateTesting.kt
@@ -14,6 +14,7 @@
 
 package org.wfanet.measurement.consent.testing
 
+import java.io.File
 import java.nio.file.Paths
 
 private val TESTDATA_DIR_PATH =
@@ -28,14 +29,19 @@ private val TESTDATA_DIR_PATH =
     "testing",
   )
 
-val EDP_1_CERT_PEM_FILE = TESTDATA_DIR_PATH.resolve("edp_1.pem").toFile()
-val EDP_1_KEY_FILE = TESTDATA_DIR_PATH.resolve("edp_1.key").toFile()
+private fun loadTestFile(filename: String): File =
+  requireNotNull(TESTDATA_DIR_PATH.resolve(filename).toFile()) {
+    "Test resource file not found: $filename"
+  }
 
-val MC_1_CERT_PEM_FILE = TESTDATA_DIR_PATH.resolve("mc_1.pem").toFile()
-val MC_1_KEY_FILE = TESTDATA_DIR_PATH.resolve("mc_1.key").toFile()
+val EDP_1_CERT_PEM_FILE = loadTestFile("edp_1.pem")
+val EDP_1_KEY_FILE = loadTestFile("edp_1.key")
 
-val DUCHY_1_NON_AGG_CERT_PEM_FILE = TESTDATA_DIR_PATH.resolve("non_aggregator_1.pem").toFile()
-val DUCHY_1_NON_AGG_KEY_FILE = TESTDATA_DIR_PATH.resolve("non_aggregator_1.key").toFile()
+val MC_1_CERT_PEM_FILE = loadTestFile("mc_1.pem")
+val MC_1_KEY_FILE = loadTestFile("mc_1.key")
 
-val DUCHY_AGG_CERT_PEM_FILE = TESTDATA_DIR_PATH.resolve("aggregator.pem").toFile()
-val DUCHY_AGG_KEY_FILE = TESTDATA_DIR_PATH.resolve("aggregator.key").toFile()
+val DUCHY_1_NON_AGG_CERT_PEM_FILE = loadTestFile("non_aggregator_1.pem")
+val DUCHY_1_NON_AGG_KEY_FILE = loadTestFile("non_aggregator_1.key")
+
+val DUCHY_AGG_CERT_PEM_FILE = loadTestFile("aggregator.pem")
+val DUCHY_AGG_KEY_FILE = loadTestFile("aggregator.key")

--- a/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
+++ b/src/main/proto/wfa/measurement/api/v2alpha/BUILD.bazel
@@ -43,3 +43,10 @@ java_proto_library(
         "@wfa_measurement_proto//src/main/proto/wfa/measurement/api/v2alpha:measurement_proto",
     ],
 )
+
+java_proto_library(
+    name = "exchange_step_java_proto",
+    deps = [
+        "@wfa_measurement_proto//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_proto",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
@@ -194,7 +194,7 @@ class MeasurementConsumerClientTest {
   }
 
   @Test
-  fun `decryptResult returns decrypted MeasurmentResult`() = runBlocking {
+  fun `decryptResult returns decrypted MeasurementResult`() = runBlocking {
     val hybridCipherSuite = HybridCipherSuite.getDefaultInstance()
     // Encrypt a Result (as SignedData) using the Duchy Aggregator Functions
     val aggregatorPrivateKeyHandle = keyStore.getPrivateKeyHandle(AGG_PRIVATE_KEY_HANDLE_KEY)

--- a/src/test/kotlin/org/wfanet/measurement/consent/crypto/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/consent/crypto/BUILD.bazel
@@ -6,6 +6,7 @@ kt_jvm_test(
     test_class = "org.wfanet.measurement.consent.crypto.SignaturesTest",
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/consent/crypto:signatures",
+        "//src/main/kotlin/org/wfanet/measurement/consent/testing",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/org/junit",
         "@wfa_common_jvm//imports/kotlin/kotlin/test",

--- a/src/test/kotlin/org/wfanet/measurement/consent/dataprovider/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/consent/dataprovider/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "DataProviderExchangeStepSignaturesTest",
+    srcs = ["DataProviderExchangeStepSignaturesTest.kt"],
+    test_class = "org.wfanet.measurement.consent.dataprovider.DataProviderExchangeStepSignaturesTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider",
+        "//src/main/kotlin/org/wfanet/measurement/consent/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/consent/dataprovider/DataProviderExchangeStepSignaturesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/dataprovider/DataProviderExchangeStepSignaturesTest.kt
@@ -1,0 +1,24 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.consent.dataprovider
+
+import org.wfanet.measurement.consent.client.dataprovider.verifyExchangeStepSignatures
+import org.wfanet.measurement.consent.testing.AbstractExchangeStepSignaturesFunctionTest
+import org.wfanet.measurement.consent.testing.verifyExchangeStepSignaturesFunction
+
+class DataProviderExchangeStepSignaturesTest : AbstractExchangeStepSignaturesFunctionTest() {
+  override val verifyExchangeStepSignatures: verifyExchangeStepSignaturesFunction =
+    ::verifyExchangeStepSignatures
+}

--- a/src/test/kotlin/org/wfanet/measurement/consent/measurementconsumer/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/consent/measurementconsumer/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "MeasurementConsumerExchangeStepSignaturesTest",
+    srcs = ["MeasurementConsumerExchangeStepSignaturesTest.kt"],
+    test_class = "org.wfanet.measurement.consent.measurementconsumer.MeasurementConsumerExchangeStepSignaturesTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer",
+        "//src/main/kotlin/org/wfanet/measurement/consent/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/measurement/consent/measurementconsumer/MeasurementConsumerExchangeStepSignaturesTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/measurementconsumer/MeasurementConsumerExchangeStepSignaturesTest.kt
@@ -1,0 +1,24 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.measurement.consent.measurementconsumer
+
+import org.wfanet.measurement.consent.client.measurementconsumer.verifyExchangeStepSignatures
+import org.wfanet.measurement.consent.testing.AbstractExchangeStepSignaturesFunctionTest
+import org.wfanet.measurement.consent.testing.verifyExchangeStepSignaturesFunction
+
+class MeasurementConsumerExchangeStepSignaturesTest : AbstractExchangeStepSignaturesFunctionTest() {
+  override val verifyExchangeStepSignatures: verifyExchangeStepSignaturesFunction =
+    ::verifyExchangeStepSignatures
+}


### PR DESCRIPTION
verifyExchangeStepSignatures() will be used in panel-exchange-client
to implement the ExchangeStepValidator

https://rally1.rallydev.com/#/?detail=/task/608172238481&fdp=true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/consent-signaling-client/19)
<!-- Reviewable:end -->
