### PR TITLE
Fix a bug in createParticipationSignature().

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,9 +25,9 @@ http_archive(
 # Common JVM for Measurement
 http_archive(
     name = "wfa_common_jvm",
-    sha256 = "8ea813bdf53743b24aa7ce70489ac7c76fcce4e7655e8ad067cdf180d5fd344f",
-    strip_prefix = "common-jvm-0.9.0",
-    url = "https://github.com/world-federation-of-advertisers/common-jvm/archive/refs/tags/v0.9.0.tar.gz",
+    sha256 = "874dad0dddd340ec5569c6518b72d18b34591178ae3c8835d030a0e917a36eeb",
+    strip_prefix = "common-jvm-0.11.0",
+    url = "https://github.com/world-federation-of-advertisers/common-jvm/archive/refs/tags/v0.11.0.tar.gz",
 )
 
 # @com_google_truth_truth

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
@@ -45,15 +45,16 @@ import org.wfanet.measurement.consent.crypto.verifySignature
  */
 suspend fun createParticipationSignature(
   requisition: Requisition,
-  dataProviderPrivateKeyHandle: PrivateKeyHandle,
-  dataProviderCertificate: X509Certificate,
+  decryptionPrivateKeyHandle: PrivateKeyHandle,
+  consentSignalingPrivateKeyHandle: PrivateKeyHandle,
+  consentSignalingCertificate: X509Certificate,
   cipherSuite: HybridCipherSuite,
   hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
 ): SignedData {
   val decryptedRequisitionSpec =
     decryptRequisitionSpec(
       requisition.encryptedRequisitionSpec,
-      dataProviderPrivateKeyHandle,
+      decryptionPrivateKeyHandle,
       cipherSuite,
       hybridEncryptionMapper
     )
@@ -65,10 +66,10 @@ suspend fun createParticipationSignature(
       .concat(requireNotNull(requisitionSpec.dataProviderListHash))
       .concat(requireNotNull(requisition.measurementSpec.data))
   val dataProviderPrivateKey: PrivateKey =
-    requireNotNull(dataProviderPrivateKeyHandle.toJavaPrivateKey(dataProviderCertificate))
+    requireNotNull(consentSignalingPrivateKeyHandle.toJavaPrivateKey(consentSignalingCertificate))
   val participationSignature =
     dataProviderPrivateKey.sign(
-      certificate = dataProviderCertificate,
+      certificate = consentSignalingCertificate,
       data = requisitionFingerprint
     )
   return SignedData.newBuilder()

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
@@ -45,16 +45,15 @@ import org.wfanet.measurement.consent.crypto.verifySignature
  */
 suspend fun createParticipationSignature(
   requisition: Requisition,
-  encryptionPrivateKeyHandle: PrivateKeyHandle,
-  consentSignalingPrivateKeyHandle: PrivateKeyHandle,
-  consentSignalingCertificate: X509Certificate,
+  dataProviderPrivateKeyHandle: PrivateKeyHandle,
+  dataProviderCertificate: X509Certificate,
   cipherSuite: HybridCipherSuite,
   hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
 ): SignedData {
   val decryptedRequisitionSpec =
     decryptRequisitionSpec(
       requisition.encryptedRequisitionSpec,
-      encryptionPrivateKeyHandle,
+      dataProviderPrivateKeyHandle,
       cipherSuite,
       hybridEncryptionMapper
     )
@@ -65,11 +64,11 @@ suspend fun createParticipationSignature(
     hashedEncryptedRequisitionSpec
       .concat(requireNotNull(requisitionSpec.dataProviderListHash))
       .concat(requireNotNull(requisition.measurementSpec.data))
-  val consentSignalingPrivateKey: PrivateKey =
-    requireNotNull(consentSignalingPrivateKeyHandle.toJavaPrivateKey(consentSignalingCertificate))
+  val dataProviderPrivateKey: PrivateKey =
+    requireNotNull(dataProviderPrivateKeyHandle.toJavaPrivateKey(dataProviderCertificate))
   val participationSignature =
-    consentSignalingPrivateKey.sign(
-      certificate = consentSignalingCertificate,
+    dataProviderPrivateKey.sign(
+      certificate = dataProviderCertificate,
       data = requisitionFingerprint
     )
   return SignedData.newBuilder()

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
@@ -17,7 +17,6 @@ package org.wfanet.measurement.consent.client.dataprovider
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
-import java.util.Base64
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.BeforeClass
@@ -28,9 +27,7 @@ import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
-import org.wfanet.measurement.api.v2alpha.Requisition
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec
-import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.crypto.readPrivateKey
 import org.wfanet.measurement.consent.client.measurementconsumer.encryptRequisitionSpec
@@ -40,7 +37,6 @@ import org.wfanet.measurement.consent.crypto.hybridencryption.testing.ReversingH
 import org.wfanet.measurement.consent.crypto.keystore.testing.InMemoryKeyStore
 import org.wfanet.measurement.consent.crypto.signMessage
 import org.wfanet.measurement.consent.crypto.testing.fakeGetHybridCryptorForCipherSuite
-import org.wfanet.measurement.consent.crypto.verifySignature
 import org.wfanet.measurement.consent.testing.DUCHY_1_NON_AGG_CERT_PEM_FILE
 import org.wfanet.measurement.consent.testing.DUCHY_1_NON_AGG_KEY_FILE
 import org.wfanet.measurement.consent.testing.EDP_1_CERT_PEM_FILE
@@ -123,29 +119,30 @@ class DataProviderClientTest {
 
   @Test
   fun `data provider calculates requisition participation signature`() = runBlocking {
-    val privateKeyHandle = keyStore.getPrivateKeyHandle(EDP_PRIVATE_KEY_HANDLE_KEY)
-    checkNotNull(privateKeyHandle)
-    val requisition =
-      Requisition.newBuilder()
-        .apply {
-          encryptedRequisitionSpec = someEncryptedRequisitionSpec
-          measurementSpec =
-            SignedData.newBuilder().apply { data = SOME_SERIALIZED_MEASUREMENT_SPEC }.build()
-        }
-        .build()
-    val dataProviderParticipation: SignedData =
-      createParticipationSignature(
-        hybridCryptor = hybridCryptor,
-        requisition = requisition,
-        privateKeyHandle = privateKeyHandle,
-        dataProviderCertificate = EDP_CERTIFICATE
-      )
-    assertThat(Base64.getEncoder().encodeToString(dataProviderParticipation.data.toByteArray()))
-      .isEqualTo(
-        "bnVXV7tDjYDhNP8KXXjP8PZ0Iu1fRT9/E5E1vjfDcr8PkHDERRYb2Dd0CVCsKEJa5IbodPlqp9Y" +
-          "awikye4ihpXNvbWUtc2VyaWFsaXplZC1tZWFzdXJlbWVudC1zcGVj"
-      )
-    assertTrue(EDP_CERTIFICATE.verifySignature(dataProviderParticipation))
+    //    val privateKeyHandle = keyStore.getPrivateKeyHandle(EDP_PRIVATE_KEY_HANDLE_KEY)
+    //    checkNotNull(privateKeyHandle)
+    //    val requisition =
+    //      Requisition.newBuilder()
+    //        .apply {
+    //          encryptedRequisitionSpec = someEncryptedRequisitionSpec
+    //          measurementSpec =
+    //            SignedData.newBuilder().apply { data = SOME_SERIALIZED_MEASUREMENT_SPEC }.build()
+    //        }
+    //        .build()
+    //    val dataProviderParticipation: SignedData =
+    //      createParticipationSignature(
+    //        hybridCryptor = hybridCryptor,
+    //        requisition = requisition,
+    //        privateKeyHandle = privateKeyHandle,
+    //        dataProviderCertificate = EDP_CERTIFICATE
+    //      )
+    //
+    // assertThat(Base64.getEncoder().encodeToString(dataProviderParticipation.data.toByteArray()))
+    //      .isEqualTo(
+    //        "bnVXV7tDjYDhNP8KXXjP8PZ0Iu1fRT9/E5E1vjfDcr8PkHDERRYb2Dd0CVCsKEJa5IbodPlqp9Y" +
+    //          "awikye4ihpXNvbWUtc2VyaWFsaXplZC1tZWFzdXJlbWVudC1zcGVj"
+    //      )
+    //    assertTrue(EDP_CERTIFICATE.verifySignature(dataProviderParticipation))
   }
 
   @Test

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
@@ -145,21 +145,26 @@ class DataProviderClientTest {
             SignedData.newBuilder().apply { data = SOME_SERIALIZED_MEASUREMENT_SPEC }.build()
         }
         .build()
-    val dataProviderParticipation: SignedData =
-      createParticipationSignature(
+    val (requisitionSpec, requistionFingerprint) =
+      processRequisitionSpec(
         requisition = requisition,
         decryptionPrivateKeyHandle = edpPrivateKeyHandle,
-        consentSignalingPrivateKeyHandle = edpPrivateKeyHandle,
-        consentSignalingCertificate = EDP_CERTIFICATE,
         cipherSuite = FAKE_MEASUREMENT_SPEC.cipherSuite,
         hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite,
       )
-
-    assertThat(HexString(dataProviderParticipation.data).value)
+    assertThat(requisitionSpec).isEqualTo(FAKE_REQUISITION_SPEC)
+    assertThat(HexString(requistionFingerprint).value)
       .isEqualTo(
         "4B4DFB2EA760051972FA3BA3F49F23584C632898FB51DD8D795B2E043BD441A90F9070C4451" +
           "61BD837740950AC28425AE486E874F96AA7D61AC229327B88A1A5736F6D652D73657269616C697A656" +
           "42D6D6561737572656D656E742D73706563"
+      )
+
+    val dataProviderParticipation =
+      signRequisitionFingerprint(
+        requisitionFingerprint = requistionFingerprint,
+        consentSignalingPrivateKeyHandle = edpPrivateKeyHandle,
+        consentSignalingCertificate = EDP_CERTIFICATE,
       )
     assertTrue(EDP_CERTIFICATE.verifySignature(dataProviderParticipation))
   }

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
@@ -17,6 +17,7 @@ package org.wfanet.measurement.consent.client.dataprovider
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
+import java.util.Base64
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.BeforeClass
@@ -27,7 +28,9 @@ import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
+import org.wfanet.measurement.api.v2alpha.Requisition
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec
+import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.crypto.readPrivateKey
 import org.wfanet.measurement.consent.client.measurementconsumer.encryptRequisitionSpec
@@ -37,6 +40,7 @@ import org.wfanet.measurement.consent.crypto.hybridencryption.testing.ReversingH
 import org.wfanet.measurement.consent.crypto.keystore.testing.InMemoryKeyStore
 import org.wfanet.measurement.consent.crypto.signMessage
 import org.wfanet.measurement.consent.crypto.testing.fakeGetHybridCryptorForCipherSuite
+import org.wfanet.measurement.consent.crypto.verifySignature
 import org.wfanet.measurement.consent.testing.DUCHY_1_NON_AGG_CERT_PEM_FILE
 import org.wfanet.measurement.consent.testing.DUCHY_1_NON_AGG_KEY_FILE
 import org.wfanet.measurement.consent.testing.EDP_1_CERT_PEM_FILE
@@ -114,35 +118,46 @@ class DataProviderClientTest {
     }
   }
 
-  private val someEncryptedRequisitionSpec =
-    hybridCryptor.encrypt(MEASUREMENT_PUBLIC_KEY, FAKE_REQUISITION_SPEC.toByteString())
-
   @Test
   fun `data provider calculates requisition participation signature`() = runBlocking {
-    //    val privateKeyHandle = keyStore.getPrivateKeyHandle(EDP_PRIVATE_KEY_HANDLE_KEY)
-    //    checkNotNull(privateKeyHandle)
-    //    val requisition =
-    //      Requisition.newBuilder()
-    //        .apply {
-    //          encryptedRequisitionSpec = someEncryptedRequisitionSpec
-    //          measurementSpec =
-    //            SignedData.newBuilder().apply { data = SOME_SERIALIZED_MEASUREMENT_SPEC }.build()
-    //        }
-    //        .build()
-    //    val dataProviderParticipation: SignedData =
-    //      createParticipationSignature(
-    //        hybridCryptor = hybridCryptor,
-    //        requisition = requisition,
-    //        privateKeyHandle = privateKeyHandle,
-    //        dataProviderCertificate = EDP_CERTIFICATE
-    //      )
-    //
-    // assertThat(Base64.getEncoder().encodeToString(dataProviderParticipation.data.toByteArray()))
-    //      .isEqualTo(
-    //        "bnVXV7tDjYDhNP8KXXjP8PZ0Iu1fRT9/E5E1vjfDcr8PkHDERRYb2Dd0CVCsKEJa5IbodPlqp9Y" +
-    //          "awikye4ihpXNvbWUtc2VyaWFsaXplZC1tZWFzdXJlbWVudC1zcGVj"
-    //      )
-    //    assertTrue(EDP_CERTIFICATE.verifySignature(dataProviderParticipation))
+    val edpPrivateKeyHandle = keyStore.getPrivateKeyHandle(EDP_PRIVATE_KEY_HANDLE_KEY)
+    checkNotNull(edpPrivateKeyHandle)
+    val requisition =
+      Requisition.newBuilder()
+        .apply {
+          encryptedRequisitionSpec =
+            encryptRequisitionSpec(
+              signedRequisitionSpec =
+              SignedData.newBuilder()
+                .apply {
+                  data = FAKE_REQUISITION_SPEC.toByteString()
+                  signature = ByteString.copyFromUtf8("predictable signature for testing")
+                }
+                .build(),
+              measurementPublicKey =
+              EncryptionPublicKey.parseFrom(FAKE_REQUISITION_SPEC.measurementPublicKey),
+              cipherSuite = FAKE_MEASUREMENT_SPEC.cipherSuite,
+              hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite,
+            )
+          measurementSpec =
+            SignedData.newBuilder().apply { data = SOME_SERIALIZED_MEASUREMENT_SPEC }.build()
+        }
+        .build()
+    val dataProviderParticipation: SignedData =
+      createParticipationSignature(
+        requisition = requisition,
+        dataProviderPrivateKeyHandle = edpPrivateKeyHandle,
+        dataProviderCertificate = EDP_CERTIFICATE,
+        cipherSuite = FAKE_MEASUREMENT_SPEC.cipherSuite,
+        hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite,
+      )
+
+    assertThat(Base64.getEncoder().encodeToString(dataProviderParticipation.data.toByteArray()))
+      .isEqualTo(
+        "S037LqdgBRly+juj9J8jWExjKJj7Ud2NeVsuBDvUQakPkHDERRYb2Dd0CVCsKEJa5IbodPlqp9Yawi" +
+          "kye4ihpXNvbWUtc2VyaWFsaXplZC1tZWFzdXJlbWVudC1zcGVj"
+      )
+    assertTrue(EDP_CERTIFICATE.verifySignature(dataProviderParticipation))
   }
 
   @Test


### PR DESCRIPTION
The encrypteRequisitionSpec is an encrypted signedData, not a
requisitionSpec.

https://rally1.rallydev.com/#/604612930531d/userstories?detail=%2Ftask%2F607228901955&view=2c2927c0-626b-4740-8620-af2a93b7d623

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/consent-signaling-client/20)
<!-- Reviewable:end -->
