### PR TITLE
Break apart createParticipationSignature into two functions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,9 +25,9 @@ http_archive(
 # Common JVM for Measurement
 http_archive(
     name = "wfa_common_jvm",
-    sha256 = "874dad0dddd340ec5569c6518b72d18b34591178ae3c8835d030a0e917a36eeb",
-    strip_prefix = "common-jvm-0.11.0",
-    url = "https://github.com/world-federation-of-advertisers/common-jvm/archive/refs/tags/v0.11.0.tar.gz",
+    sha256 = "f9b2be33d3515a66e28feff14ca7405a73b4853f28912f69175bddc183805b92",
+    strip_prefix = "common-jvm-0.13.0",
+    url = "https://github.com/world-federation-of-advertisers/common-jvm/archive/refs/tags/v0.13.0.tar.gz",
 )
 
 # @com_google_truth_truth

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,9 +25,9 @@ http_archive(
 # Common JVM for Measurement
 http_archive(
     name = "wfa_common_jvm",
-    sha256 = "8ea813bdf53743b24aa7ce70489ac7c76fcce4e7655e8ad067cdf180d5fd344f",
-    strip_prefix = "common-jvm-0.9.0",
-    url = "https://github.com/world-federation-of-advertisers/common-jvm/archive/refs/tags/v0.9.0.tar.gz",
+    sha256 = "874dad0dddd340ec5569c6518b72d18b34591178ae3c8835d030a0e917a36eeb",
+    strip_prefix = "common-jvm-0.11.0",
+    url = "https://github.com/world-federation-of-advertisers/common-jvm/archive/refs/tags/v0.11.0.tar.gz",
 )
 
 # @com_google_truth_truth

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
@@ -145,24 +145,26 @@ class DataProviderClientTest {
             SignedData.newBuilder().apply { data = SOME_SERIALIZED_MEASUREMENT_SPEC }.build()
         }
         .build()
-    val (requisitionSpec, requistionFingerprint) =
-      processRequisitionSpec(
+    val requisitionSpecAndFingerprint =
+      decryptRequisitionSpecAndGenerateRequisitionFingerprint(
         requisition = requisition,
         decryptionPrivateKeyHandle = edpPrivateKeyHandle,
         cipherSuite = FAKE_MEASUREMENT_SPEC.cipherSuite,
         hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite,
       )
-    assertThat(requisitionSpec).isEqualTo(FAKE_REQUISITION_SPEC)
-    assertThat(HexString(requistionFingerprint).value)
+    assertThat(requisitionSpecAndFingerprint.requisitionSpec).isEqualTo(FAKE_REQUISITION_SPEC)
+    assertThat(HexString(requisitionSpecAndFingerprint.requisitionFingerprint))
       .isEqualTo(
-        "4B4DFB2EA760051972FA3BA3F49F23584C632898FB51DD8D795B2E043BD441A90F9070C4451" +
-          "61BD837740950AC28425AE486E874F96AA7D61AC229327B88A1A5736F6D652D73657269616C697A656" +
-          "42D6D6561737572656D656E742D73706563"
+        HexString(
+          "4B4DFB2EA760051972FA3BA3F49F23584C632898FB51DD8D795B2E043BD441A90F9070C4451" +
+            "61BD837740950AC28425AE486E874F96AA7D61AC229327B88A1A5736F6D652D73657269616C697A656" +
+            "42D6D6561737572656D656E742D73706563"
+        )
       )
 
     val dataProviderParticipation =
       signRequisitionFingerprint(
-        requisitionFingerprint = requistionFingerprint,
+        requisitionFingerprint = requisitionSpecAndFingerprint.requisitionFingerprint,
         consentSignalingPrivateKeyHandle = edpPrivateKeyHandle,
         consentSignalingCertificate = EDP_CERTIFICATE,
       )

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
@@ -17,7 +17,6 @@ package org.wfanet.measurement.consent.client.dataprovider
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
-import java.util.Base64
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.BeforeClass
@@ -31,6 +30,7 @@ import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.Requisition
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec
 import org.wfanet.measurement.api.v2alpha.SignedData
+import org.wfanet.measurement.common.HexString
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.crypto.readPrivateKey
 import org.wfanet.measurement.consent.client.measurementconsumer.encryptRequisitionSpec
@@ -118,32 +118,53 @@ class DataProviderClientTest {
     }
   }
 
-  private val someEncryptedRequisitionSpec =
-    hybridCryptor.encrypt(MEASUREMENT_PUBLIC_KEY, FAKE_REQUISITION_SPEC.toByteString())
-
   @Test
   fun `data provider calculates requisition participation signature`() = runBlocking {
-    val privateKeyHandle = keyStore.getPrivateKeyHandle(EDP_PRIVATE_KEY_HANDLE_KEY)
-    checkNotNull(privateKeyHandle)
+    val edpPrivateKeyHandle = keyStore.getPrivateKeyHandle(EDP_PRIVATE_KEY_HANDLE_KEY)
+    checkNotNull(edpPrivateKeyHandle)
+    val signedRequisitionSpec =
+      SignedData.newBuilder()
+        .apply {
+          data = FAKE_REQUISITION_SPEC.toByteString()
+          signature = ByteString.copyFromUtf8("predictable signature for testing")
+        }
+        .build()
+    val measurementPublicKey =
+      EncryptionPublicKey.parseFrom(FAKE_REQUISITION_SPEC.measurementPublicKey)
     val requisition =
       Requisition.newBuilder()
         .apply {
-          encryptedRequisitionSpec = someEncryptedRequisitionSpec
+          encryptedRequisitionSpec =
+            encryptRequisitionSpec(
+              signedRequisitionSpec = signedRequisitionSpec,
+              measurementPublicKey = measurementPublicKey,
+              cipherSuite = FAKE_MEASUREMENT_SPEC.cipherSuite,
+              hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite,
+            )
           measurementSpec =
             SignedData.newBuilder().apply { data = SOME_SERIALIZED_MEASUREMENT_SPEC }.build()
         }
         .build()
-    val dataProviderParticipation: SignedData =
-      createParticipationSignature(
-        hybridCryptor = hybridCryptor,
+    val (requisitionSpec, requistionFingerprint) =
+      processRequisitionSpec(
         requisition = requisition,
-        privateKeyHandle = privateKeyHandle,
-        dataProviderCertificate = EDP_CERTIFICATE
+        decryptionPrivateKeyHandle = edpPrivateKeyHandle,
+        cipherSuite = FAKE_MEASUREMENT_SPEC.cipherSuite,
+        hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite,
       )
-    assertThat(Base64.getEncoder().encodeToString(dataProviderParticipation.data.toByteArray()))
+    assertThat(requisitionSpec).isEqualTo(FAKE_REQUISITION_SPEC)
+    assertThat(HexString(requistionFingerprint).value)
       .isEqualTo(
-        "bnVXV7tDjYDhNP8KXXjP8PZ0Iu1fRT9/E5E1vjfDcr8PkHDERRYb2Dd0CVCsKEJa5IbodPlqp9Y" +
-          "awikye4ihpXNvbWUtc2VyaWFsaXplZC1tZWFzdXJlbWVudC1zcGVj"
+        "4B4DFB2EA760051972FA3BA3F49F23584C632898FB51DD8D795B2E043BD441A90F9070C4451" +
+          "61BD837740950AC28425AE486E874F96AA7D61AC229327B88A1A5736F6D652D73657269616C697A656" +
+          "42D6D6561737572656D656E742D73706563"
+      )
+
+    val dataProviderParticipation =
+      signRequisitionFingerprint(
+        requisitionFingerprint = requistionFingerprint,
+        consentSignalingPrivateKeyHandle = edpPrivateKeyHandle,
+        consentSignalingCertificate = EDP_CERTIFICATE,
       )
     assertTrue(EDP_CERTIFICATE.verifySignature(dataProviderParticipation))
   }


### PR DESCRIPTION
- Create two functions from createParticipationSignature
  - processRequisition - decrypts requisitionSpec from the requistion and generates the requisitionFingerprint (and returns both)
  - signRequisitionFingerprint - signs the requisitionFingerprint
- Fix a bug in createParticipationSignature().
  - The encrypteRequisitionSpec is an encrypted signedData, not a requisitionSpec.
- Update to use HexString from jvm-common instead of Base64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/consent-signaling-client/22)
<!-- Reviewable:end -->
