### PR TITLE
Return signedData instead of RequisitionSpec proto.

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
@@ -35,8 +35,8 @@ import org.wfanet.measurement.consent.crypto.verifyExchangeStepSignatures as ver
 import org.wfanet.measurement.consent.crypto.verifySignature
 
 data class RequisitionSpecAndFingerprint(
-  /** Decrypted RequisitionSpec */
-  val requisitionSpec: RequisitionSpec,
+  /** Decrypted Signed RequisitionSpec */
+  val signedRequisitionSpec: SignedData,
   /** Generated Requisition Fingerprint */
   val requisitionFingerprint: ByteString,
 )
@@ -72,7 +72,7 @@ suspend fun decryptRequisitionSpecAndGenerateRequisitionFingerprint(
     hashedEncryptedRequisitionSpec
       .concat(requireNotNull(requisitionSpec.dataProviderListHash))
       .concat(requireNotNull(requisition.measurementSpec.data))
-  return RequisitionSpecAndFingerprint(requisitionSpec, requisitionFingerprint)
+  return RequisitionSpecAndFingerprint(decryptedRequisitionSpec, requisitionFingerprint)
 }
 
 /** Signs the RequisitionFingerprint resulting in the participationSignature */

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
@@ -152,7 +152,7 @@ class DataProviderClientTest {
         cipherSuite = FAKE_MEASUREMENT_SPEC.cipherSuite,
         hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite,
       )
-    assertThat(requisitionSpecAndFingerprint.requisitionSpec).isEqualTo(FAKE_REQUISITION_SPEC)
+    assertThat(requisitionSpecAndFingerprint.signedRequisitionSpec).isEqualTo(signedRequisitionSpec)
     assertThat(HexString(requisitionSpecAndFingerprint.requisitionFingerprint))
       .isEqualTo(
         HexString(


### PR DESCRIPTION
The EDP still needs to use the signedData to verify the requisitionSpec,
which happens outside this method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/consent-signaling-client/23)
<!-- Reviewable:end -->
