### PR TITLE
Interim fix for HybridCipherSuite deprecation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,9 +25,9 @@ http_archive(
 # Common JVM for Measurement
 http_archive(
     name = "wfa_common_jvm",
-    sha256 = "f9b2be33d3515a66e28feff14ca7405a73b4853f28912f69175bddc183805b92",
-    strip_prefix = "common-jvm-0.13.0",
-    url = "https://github.com/world-federation-of-advertisers/common-jvm/archive/refs/tags/v0.13.0.tar.gz",
+    sha256 = "cbc253d5a240b5587d8defbf2af08772d0eda997aa348c7ed870f413750abc35",
+    strip_prefix = "common-jvm-0.16.0",
+    url = "https://github.com/world-federation-of-advertisers/common-jvm/archive/refs/tags/v0.16.0.tar.gz",
 )
 
 # @com_google_truth_truth
@@ -165,7 +165,7 @@ switched_rules_by_language(
 # Measurement proto.
 http_archive(
     name = "wfa_measurement_proto",
-    sha256 = "9a4f5054f4a2b4d03ad8398436e04781f39b20f8ad13da15cbc80f21d69b888f",
-    strip_prefix = "cross-media-measurement-api-c742b249dcdcb1731899b2a8d61e9fcf1b597ca7",
-    url = "https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/c742b249dcdcb1731899b2a8d61e9fcf1b597ca7.tar.gz",
+    sha256 = "1ce85f62abe07fc6921d0b6599289844ffca7b39c56cd6bd8121ada19d1c4ec2",
+    strip_prefix = "cross-media-measurement-api-0.7.2",
+    url = "https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/refs/tags/v0.7.2.tar.gz",
 )

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
@@ -17,10 +17,10 @@ package org.wfanet.measurement.consent.client.dataprovider
 import com.google.protobuf.ByteString
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
+import kotlin.reflect.KFunction0
 import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
-import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.Requisition
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec
@@ -55,14 +55,12 @@ data class RequisitionSpecAndFingerprint(
 suspend fun decryptRequisitionSpecAndGenerateRequisitionFingerprint(
   requisition: Requisition,
   decryptionPrivateKeyHandle: PrivateKeyHandle,
-  cipherSuite: HybridCipherSuite,
-  hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
+  hybridEncryptionMapper: KFunction0<HybridCryptor> = ::getHybridCryptorForCipherSuite,
 ): RequisitionSpecAndFingerprint {
   val decryptedRequisitionSpec =
     decryptRequisitionSpec(
       requisition.encryptedRequisitionSpec,
       decryptionPrivateKeyHandle,
-      cipherSuite,
       hybridEncryptionMapper
     )
   // There is no salt when hashing the encrypted requisition spec
@@ -133,10 +131,9 @@ fun verifyMeasurementSpec(
 suspend fun decryptRequisitionSpec(
   encryptedSignedDataRequisitionSpec: ByteString,
   dataProviderPrivateKeyHandle: PrivateKeyHandle,
-  cipherSuite: HybridCipherSuite,
-  hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
+  hybridEncryptionMapper: KFunction0<HybridCryptor> = ::getHybridCryptorForCipherSuite,
 ): SignedData {
-  val hybridCryptor: HybridCryptor = hybridEncryptionMapper(cipherSuite)
+  val hybridCryptor: HybridCryptor = hybridEncryptionMapper()
   return SignedData.parseFrom(
     hybridCryptor.decrypt(dataProviderPrivateKeyHandle, encryptedSignedDataRequisitionSpec)
   )

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
@@ -17,7 +17,6 @@ package org.wfanet.measurement.consent.client.dataprovider
 import com.google.protobuf.ByteString
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
-import kotlin.reflect.KFunction0
 import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
@@ -55,7 +54,7 @@ data class RequisitionSpecAndFingerprint(
 suspend fun decryptRequisitionSpecAndGenerateRequisitionFingerprint(
   requisition: Requisition,
   decryptionPrivateKeyHandle: PrivateKeyHandle,
-  hybridEncryptionMapper: KFunction0<HybridCryptor> = ::getHybridCryptorForCipherSuite,
+  hybridEncryptionMapper: () -> HybridCryptor = ::getHybridCryptorForCipherSuite,
 ): RequisitionSpecAndFingerprint {
   val decryptedRequisitionSpec =
     decryptRequisitionSpec(
@@ -131,7 +130,7 @@ fun verifyMeasurementSpec(
 suspend fun decryptRequisitionSpec(
   encryptedSignedDataRequisitionSpec: ByteString,
   dataProviderPrivateKeyHandle: PrivateKeyHandle,
-  hybridEncryptionMapper: KFunction0<HybridCryptor> = ::getHybridCryptorForCipherSuite,
+  hybridEncryptionMapper: () -> HybridCryptor = ::getHybridCryptorForCipherSuite,
 ): SignedData {
   val hybridCryptor: HybridCryptor = hybridEncryptionMapper()
   return SignedData.parseFrom(

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClient.kt
@@ -16,9 +16,9 @@ package org.wfanet.measurement.consent.client.duchy
 
 import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
+import kotlin.reflect.KFunction0
 import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
-import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResult
 import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.consent.crypto.getHybridCryptorForCipherSuite
@@ -97,10 +97,9 @@ suspend fun signResult(
 fun encryptResult(
   signedResult: SignedData,
   measurementPublicKey: EncryptionPublicKey,
-  cipherSuite: HybridCipherSuite,
-  hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
+  hybridEncryptionMapper: KFunction0<HybridCryptor> = ::getHybridCryptorForCipherSuite,
 ): ByteString {
-  val hybridCryptor: HybridCryptor = hybridEncryptionMapper(cipherSuite)
+  val hybridCryptor: HybridCryptor = hybridEncryptionMapper()
   return hybridCryptor.encrypt(measurementPublicKey, signedResult.toByteString())
 }
 

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClient.kt
@@ -16,7 +16,6 @@ package org.wfanet.measurement.consent.client.duchy
 
 import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
-import kotlin.reflect.KFunction0
 import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResult
@@ -97,7 +96,7 @@ suspend fun signResult(
 fun encryptResult(
   signedResult: SignedData,
   measurementPublicKey: EncryptionPublicKey,
-  hybridEncryptionMapper: KFunction0<HybridCryptor> = ::getHybridCryptorForCipherSuite,
+  hybridEncryptionMapper: () -> HybridCryptor = ::getHybridCryptorForCipherSuite,
 ): ByteString {
   val hybridCryptor: HybridCryptor = hybridEncryptionMapper()
   return hybridCryptor.encrypt(measurementPublicKey, signedResult.toByteString())

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -16,7 +16,6 @@ package org.wfanet.measurement.consent.client.measurementconsumer
 
 import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
-import kotlin.reflect.KFunction0
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResult
@@ -62,7 +61,7 @@ suspend fun signRequisitionSpec(
 fun encryptRequisitionSpec(
   signedRequisitionSpec: SignedData,
   measurementPublicKey: EncryptionPublicKey,
-  hybridEncryptionMapper: KFunction0<HybridCryptor> = ::getHybridCryptorForCipherSuite,
+  hybridEncryptionMapper: () -> HybridCryptor = ::getHybridCryptorForCipherSuite,
 ): ByteString {
   val hybridCryptor: HybridCryptor = hybridEncryptionMapper()
   return hybridCryptor.encrypt(measurementPublicKey, signedRequisitionSpec.toByteString())
@@ -104,7 +103,7 @@ suspend fun signEncryptionPublicKey(
 suspend fun decryptResult(
   encryptedSignedDataResult: ByteString,
   measurementPrivateKeyHandle: PrivateKeyHandle,
-  hybridEncryptionMapper: KFunction0<HybridCryptor> = ::getHybridCryptorForCipherSuite,
+  hybridEncryptionMapper: () -> HybridCryptor = ::getHybridCryptorForCipherSuite,
 ): SignedData {
   val hybridCryptor: HybridCryptor = hybridEncryptionMapper()
   return SignedData.parseFrom(

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -16,9 +16,9 @@ package org.wfanet.measurement.consent.client.measurementconsumer
 
 import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
+import kotlin.reflect.KFunction0
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
-import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResult
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec
@@ -62,10 +62,9 @@ suspend fun signRequisitionSpec(
 fun encryptRequisitionSpec(
   signedRequisitionSpec: SignedData,
   measurementPublicKey: EncryptionPublicKey,
-  cipherSuite: HybridCipherSuite,
-  hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
+  hybridEncryptionMapper: KFunction0<HybridCryptor> = ::getHybridCryptorForCipherSuite,
 ): ByteString {
-  val hybridCryptor: HybridCryptor = hybridEncryptionMapper(cipherSuite)
+  val hybridCryptor: HybridCryptor = hybridEncryptionMapper()
   return hybridCryptor.encrypt(measurementPublicKey, signedRequisitionSpec.toByteString())
 }
 
@@ -105,10 +104,9 @@ suspend fun signEncryptionPublicKey(
 suspend fun decryptResult(
   encryptedSignedDataResult: ByteString,
   measurementPrivateKeyHandle: PrivateKeyHandle,
-  cipherSuite: HybridCipherSuite,
-  hybridEncryptionMapper: (HybridCipherSuite) -> HybridCryptor = ::getHybridCryptorForCipherSuite,
+  hybridEncryptionMapper: KFunction0<HybridCryptor> = ::getHybridCryptorForCipherSuite,
 ): SignedData {
-  val hybridCryptor: HybridCryptor = hybridEncryptionMapper(cipherSuite)
+  val hybridCryptor: HybridCryptor = hybridEncryptionMapper()
   return SignedData.parseFrom(
     hybridCryptor.decrypt(measurementPrivateKeyHandle, encryptedSignedDataResult)
   )

--- a/src/main/kotlin/org/wfanet/measurement/consent/crypto/Utils.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/crypto/Utils.kt
@@ -18,7 +18,6 @@ import com.google.protobuf.Message
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
-import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.consent.crypto.hybridencryption.EciesCryptor
 import org.wfanet.measurement.consent.crypto.hybridencryption.HybridCryptor
@@ -42,14 +41,8 @@ suspend fun <T : Message> signMessage(
 }
 
 /** Maps based on kem and dem types. */
-fun getHybridCryptorForCipherSuite(cipherSuite: HybridCipherSuite): HybridCryptor {
-  return when (Pair(cipherSuite.kem, cipherSuite.dem)) {
-    Pair(
-      HybridCipherSuite.KeyEncapsulationMechanism.ECDH_P256_HKDF_HMAC_SHA256,
-      HybridCipherSuite.DataEncapsulationMechanism.AES_128_GCM
-    ) -> EciesCryptor()
-    else -> throw IllegalArgumentException("Unsupported cipher suite")
-  }
+fun getHybridCryptorForCipherSuite(): HybridCryptor {
+  return EciesCryptor()
 }
 
 /**

--- a/src/main/kotlin/org/wfanet/measurement/consent/crypto/testing/FakeUtils.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/crypto/testing/FakeUtils.kt
@@ -14,11 +14,10 @@
 
 package org.wfanet.measurement.consent.crypto.testing
 
-import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.consent.crypto.hybridencryption.HybridCryptor
 import org.wfanet.measurement.consent.crypto.hybridencryption.testing.ReversingHybridCryptor
 
 /** Always returns [ReversingHybridCryptor] regardless of input [HybridCipherSuite]. */
-fun fakeGetHybridCryptorForCipherSuite(cipherSuite: HybridCipherSuite): HybridCryptor {
+fun fakeGetHybridCryptorForCipherSuite(): HybridCryptor {
   return ReversingHybridCryptor()
 }

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
-import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.Requisition
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec
@@ -50,7 +49,7 @@ import org.wfanet.measurement.consent.testing.MC_1_KEY_FILE
 
 private val MEASUREMENT_PUBLIC_KEY =
   EncryptionPublicKey.newBuilder()
-    .apply { publicKeyInfo = ByteString.copyFromUtf8("some-public-key") }
+    .apply { data = ByteString.copyFromUtf8("some-public-key") }
     .build()
 private val SOME_DATA_PROVIDER_LIST_SALT = ByteString.copyFromUtf8("some-salt-0")
 private val SOME_SERIALIZED_DATA_PROVIDER_LIST = ByteString.copyFromUtf8("some-data-provider-list")
@@ -62,10 +61,7 @@ private val hybridCryptor = ReversingHybridCryptor()
 
 private val FAKE_MEASUREMENT_SPEC =
   MeasurementSpec.newBuilder()
-    .apply {
-      cipherSuite = HybridCipherSuite.getDefaultInstance()
-      measurementPublicKey = MEASUREMENT_PUBLIC_KEY.toByteString()
-    }
+    .apply { measurementPublicKey = MEASUREMENT_PUBLIC_KEY.toByteString() }
     .build()
 
 private val FAKE_REQUISITION_SPEC =
@@ -138,7 +134,6 @@ class DataProviderClientTest {
             encryptRequisitionSpec(
               signedRequisitionSpec = signedRequisitionSpec,
               measurementPublicKey = measurementPublicKey,
-              cipherSuite = FAKE_MEASUREMENT_SPEC.cipherSuite,
               hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite,
             )
           measurementSpec =
@@ -149,7 +144,6 @@ class DataProviderClientTest {
       decryptRequisitionSpecAndGenerateRequisitionFingerprint(
         requisition = requisition,
         decryptionPrivateKeyHandle = edpPrivateKeyHandle,
-        cipherSuite = FAKE_MEASUREMENT_SPEC.cipherSuite,
         hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite,
       )
     assertThat(requisitionSpecAndFingerprint.signedRequisitionSpec).isEqualTo(signedRequisitionSpec)
@@ -193,7 +187,6 @@ class DataProviderClientTest {
 
   @Test
   fun `decryptRequistionSpec returns decrypted RequistionSpec`() = runBlocking {
-    val hybridCipherSuite = HybridCipherSuite.getDefaultInstance()
     // Encrypt a RequisitionSpec (as SignedData) using the Measurement Consumer Functions
     val measurementConsumerPrivateKeyHandle =
       keyStore.getPrivateKeyHandle(MC_PRIVATE_KEY_HANDLE_KEY)
@@ -208,7 +201,6 @@ class DataProviderClientTest {
       encryptRequisitionSpec(
         signedRequisitionSpec = signedRequisitionSpec,
         measurementPublicKey = EDP_PUBLIC_KEY,
-        cipherSuite = hybridCipherSuite,
         hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite
       )
 
@@ -219,7 +211,6 @@ class DataProviderClientTest {
       decryptRequisitionSpec(
         encryptedRequisitionSpec,
         privateKeyHandle,
-        hybridCipherSuite,
         ::fakeGetHybridCryptorForCipherSuite
       )
     val decryptedRequisitionSpec =

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClientTest.kt
@@ -26,9 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
-import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResult
-import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec
 import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.common.crypto.readCertificate
@@ -48,7 +46,7 @@ private val SOME_DATA_PROVIDER_LIST_SALT = ByteString.copyFromUtf8("some-salt-0"
 private val SOME_SERIALIZED_DATA_PROVIDER_LIST = ByteString.copyFromUtf8("some-data-provider-list")
 private val DATA_PROVIDER_PUBLIC_KEY =
   EncryptionPublicKey.newBuilder()
-    .apply { publicKeyInfo = ByteString.copyFromUtf8("some-public-key") }
+    .apply { data = ByteString.copyFromUtf8("some-public-key") }
     .build()
 /** We use a fixed certificate so we can verify the signature against a known certificate. */
 private val DATA_PROVIDER_X509: X509Certificate = readCertificate(EDP_1_CERT_PEM_FILE)
@@ -118,11 +116,11 @@ class DuchyClientTest {
         .build()
     val aggregatorPrivateKeyHandleKey = "some arbitrary key"
     val aggregatorPrivateKey: PrivateKey =
-      readPrivateKey(DUCHY_AGG_KEY_FILE, aggregatorX509.getPublicKey().algorithm)
+      readPrivateKey(DUCHY_AGG_KEY_FILE, aggregatorX509.publicKey.algorithm)
     val aggregatorPrivateKeyHandle =
       keyStore.storePrivateKeyDer(
         aggregatorPrivateKeyHandleKey,
-        ByteString.copyFrom(aggregatorPrivateKey.getEncoded())
+        ByteString.copyFrom(aggregatorPrivateKey.encoded)
       )
     val signedResult =
       signResult(
@@ -148,22 +146,16 @@ class DuchyClientTest {
     val aggregatorPrivateKeyHandleKey = "some arbitrary key"
     val aggregatorX509: X509Certificate = readCertificate(DUCHY_AGG_CERT_PEM_FILE)
     val aggregatorPrivateKey: PrivateKey =
-      readPrivateKey(DUCHY_AGG_KEY_FILE, aggregatorX509.getPublicKey().algorithm)
+      readPrivateKey(DUCHY_AGG_KEY_FILE, aggregatorX509.publicKey.algorithm)
     val aggregatorPrivateKeyHandle =
       keyStore.storePrivateKeyDer(
         aggregatorPrivateKeyHandleKey,
-        ByteString.copyFrom(aggregatorPrivateKey.getEncoded())
+        ByteString.copyFrom(aggregatorPrivateKey.encoded)
       )
-    val measurementSpec =
-      MeasurementSpec.newBuilder()
-        .apply { cipherSuite = HybridCipherSuite.getDefaultInstance() }
-        .build()
-
     val encryptedSignedResult =
       encryptResult(
         signedResult = someSignedMeasurementResult,
         measurementPublicKey = measurementPublicKey,
-        cipherSuite = measurementSpec.cipherSuite,
         hybridEncryptionMapper = ::fakeGetHybridCryptorForCipherSuite
       )
     val decryptedSignedResult =

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/kingdom/KingdomClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/kingdom/KingdomClientTest.kt
@@ -23,7 +23,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
-import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.common.crypto.readCertificate
 import org.wfanet.measurement.common.crypto.readPrivateKey
@@ -34,17 +33,14 @@ import org.wfanet.measurement.consent.testing.MC_1_KEY_FILE
 
 private val MEASUREMENT_PUBLIC_KEY =
   EncryptionPublicKey.newBuilder()
-    .apply { publicKeyInfo = ByteString.copyFromUtf8("some-public-key") }
+    .apply { data = ByteString.copyFromUtf8("some-public-key") }
     .build()
 
 private val keyStore = InMemoryKeyStore()
 
 private val FAKE_MEASUREMENT_SPEC =
   MeasurementSpec.newBuilder()
-    .apply {
-      cipherSuite = HybridCipherSuite.getDefaultInstance()
-      measurementPublicKey = MEASUREMENT_PUBLIC_KEY.toByteString()
-    }
+    .apply { measurementPublicKey = MEASUREMENT_PUBLIC_KEY.toByteString() }
     .build()
 
 private val MC_CERTIFICATE: X509Certificate = readCertificate(MC_1_CERT_PEM_FILE)

--- a/src/test/kotlin/org/wfanet/measurement/consent/crypto/testing/FakeUtilsTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/crypto/testing/FakeUtilsTest.kt
@@ -18,7 +18,6 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.wfanet.measurement.api.v2alpha.HybridCipherSuite
 import org.wfanet.measurement.consent.crypto.hybridencryption.testing.ReversingHybridCryptor
 
 @RunWith(JUnit4::class)
@@ -26,28 +25,7 @@ class FakeUtilsTest {
 
   @Test
   fun `supported cipher suite maps to to ReversingHybridCryptor`() {
-    val cipherSuite =
-      HybridCipherSuite.newBuilder()
-        .apply {
-          kem = HybridCipherSuite.KeyEncapsulationMechanism.ECDH_P256_HKDF_HMAC_SHA256
-          dem = HybridCipherSuite.DataEncapsulationMechanism.AES_128_GCM
-        }
-        .build()
-    val hybridCryptor = fakeGetHybridCryptorForCipherSuite(cipherSuite)
-    assertThat(hybridCryptor).isInstanceOf(ReversingHybridCryptor::class.java)
-  }
-
-  @Test
-  fun `unsupported cipher suite maps to to ReversingHybridCryptor`() {
-    val cipherSuite =
-      HybridCipherSuite.newBuilder()
-        .apply {
-          kem = HybridCipherSuite.KeyEncapsulationMechanism.KEY_ENCAPSULATION_MECHANISM_UNSPECIFIED
-          dem =
-            HybridCipherSuite.DataEncapsulationMechanism.DATA_ENCAPSULATION_MECHANISM_UNSPECIFIED
-        }
-        .build()
-    val hybridCryptor = fakeGetHybridCryptorForCipherSuite(cipherSuite)
+    val hybridCryptor = fakeGetHybridCryptorForCipherSuite()
     assertThat(hybridCryptor).isInstanceOf(ReversingHybridCryptor::class.java)
   }
 }


### PR DESCRIPTION
- Upgrade common-jvm and cross-media-measurement-api
- This fix is to unblock from HybridCipherSuite being drop/deprecated
- I chose not to remove hybridEncyptionMapper (at this time) because otherwise we'd have to hardcode the ReversingHybridCryptor.
- hybridEncryptionMapper will be completly drop in a follow up commit when full tink impl and encryption is avaialble

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/consent-signaling-client/24)
<!-- Reviewable:end -->
