### PR TITLE
Update cross-media-measurement-api to 0.14.0.

### DIFF
--- a/build/consent_signaling_client_repositories.bzl
+++ b/build/consent_signaling_client_repositories.bzl
@@ -31,7 +31,7 @@ def consent_signaling_client_repositories():
 
     http_archive(
         name = "wfa_measurement_proto",
-        sha256 = "4385a6ae12684d8896affdd60c19a470b284623b5094685dd3a616fd30178c52",
-        strip_prefix = "cross-media-measurement-api-0.9.0",
-        url = "https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/refs/tags/v0.9.0.tar.gz",
+        sha256 = "611bbc8c653868c1dbc973a520a192d8ac1678375167181354fc9b1bc8e3a3ea",
+        strip_prefix = "cross-media-measurement-api-0.14.0",
+        url = "https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/refs/tags/v0.14.0.tar.gz",
     )

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/BUILD.bazel
@@ -12,6 +12,7 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/api/v2alpha:certificate_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_kt_jvm_proto",
+        "//src/main/proto/wfa/measurement/api/v2alpha:measurement_spec_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:requisition_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:requisition_spec_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/org/conscrypt",

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClient.kt
@@ -19,6 +19,7 @@ import java.security.cert.X509Certificate
 import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.EncryptionPublicKey
 import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResult
+import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.common.crypto.hashSha256
 import org.wfanet.measurement.consent.crypto.getHybridCryptorForCipherSuite
@@ -27,49 +28,53 @@ import org.wfanet.measurement.consent.crypto.keystore.PrivateKeyHandle
 import org.wfanet.measurement.consent.crypto.signMessage
 import org.wfanet.measurement.consent.crypto.verifySignature
 
-/** Fields from the computationDetails proto of the internal duchy api */
-data class Computation(
-  /** Serialized `DataProviderList`. */
-  val dataProviderList: ByteString,
-  /** Salt for SHA256 hash of `dataProviderList`. */
-  val dataProviderListSalt: ByteString,
-  /** Serialized `MeasurementSpec`. */
-  val measurementSpec: ByteString
+/** Data about a Requisition that Duchy received from Kingdom. */
+data class Requisition(
+  /** Pre-computed requisition fingerprint. */
+  val requisitionFingerprint: ByteString,
+  /** SHA256 hash of nonce. */
+  val nonceHash: ByteString
 )
 
-/** Fields from the requisitionDetails proto of the internal duchy api */
-data class Requisition(
-  /**
-   * X.509 certificate in DER format which can be verified using the `DataProvider`'s root
-   * certificate.
-   */
-  val dataProviderCertificate: X509Certificate,
-  /** SHA256 hash of encrypted `RequisitionSpec`. */
-  val requisitionSpecHash: ByteString
-)
+/** Computes the "requisition fingerprint" for a requisition. */
+fun computeRequisitionFingerprint(
+  serializedMeasurementSpec: ByteString,
+  requisitionSpecHash: ByteString
+): ByteString {
+  return hashSha256(serializedMeasurementSpec.concat(requisitionSpecHash))
+}
 
 /**
- * For each EDP it receives input from:
- * 1. Independently rebuilds the requisitionFingerprint with data from Kingdom
- * 2. Verifies the EdpParticipationSignature against the fingerprint
- * 3. TODO: Check for replay attacks for dataProviderParticipationSignature
- * 4. TODO: Verify certificate chain for requisition.dataProviderCertificate
+ * Verifies the parameters that an EDP passes when fulfilling a Requisition.
+ *
+ * @param measurementSpec [MeasurementSpec] retrieved from Kingdom
+ * @param requisition data about the Requisition retrieved from Kingdom
+ *
+ * The steps are:
+ * 1. Compare the requisition fingerprint to the one independently computed from Kingdom data.
+ * 2. Compute the hash of the nonce and compare it to the one from the Kingdom.
+ * 3. Verify that the list in [measurementSpec] contains the nonce hash.
  */
-fun verifyDataProviderParticipation(
-  dataProviderParticipationSignature: ByteString,
+fun verifyRequisitionFulfillment(
+  measurementSpec: MeasurementSpec,
   requisition: Requisition,
-  computation: Computation
+  requisitionFingerprint: ByteString,
+  nonce: Long
 ): Boolean {
-  val hashedParticipantList: ByteString =
-    hashSha256(computation.dataProviderList.concat(computation.dataProviderListSalt))
-  val requisitionFingerprint =
-    requireNotNull(requisition.requisitionSpecHash)
-      .concat(hashedParticipantList)
-      .concat(requireNotNull(computation.measurementSpec))
-  return requisition.dataProviderCertificate.verifySignature(
-    requisitionFingerprint,
-    dataProviderParticipationSignature
-  )
+  val nonceHash = hashSha256(nonce)
+  return requisitionFingerprint == requisition.requisitionFingerprint &&
+    nonceHash == requisition.nonceHash &&
+    measurementSpec.nonceHashesList.contains(nonceHash)
+}
+
+/** Verifies that all expected DataProviders have participated in the Computation. */
+fun verifyDataProviderParticipation(
+  measurementSpec: MeasurementSpec,
+  nonces: Iterable<Long>
+): Boolean {
+  val computedNonceHashes = nonces.map { hashSha256(it) }.toSet()
+  return measurementSpec.nonceHashesCount == computedNonceHashes.size &&
+    computedNonceHashes.containsAll(measurementSpec.nonceHashesList)
 }
 
 /**

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/BUILD.bazel
@@ -19,7 +19,6 @@ kt_jvm_test(
         "//src/main/proto/wfa/measurement/api/v2alpha:requisition_spec_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/org/junit",
-        "@wfa_common_jvm//imports/kotlin/kotlin/test",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/testing",
     ],
 )

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/duchy/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/duchy/BUILD.bazel
@@ -18,7 +18,6 @@ kt_jvm_test(
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_spec_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/org/junit",
-        "@wfa_common_jvm//imports/kotlin/kotlin/test",
         "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/testing",
     ],

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
@@ -20,7 +20,6 @@ kt_jvm_test(
         "@wfa_common_jvm//imports/java/com/google/common/truth",
         "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
         "@wfa_common_jvm//imports/java/org/junit",
-        "@wfa_common_jvm//imports/kotlin/kotlin/test",
         "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto/testing",
     ],


### PR DESCRIPTION
This handles the API changes to use nonces for verification of EDP participation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/consent-signaling-client/29)
<!-- Reviewable:end -->
