### PR TITLE
Update functions of verifying signature

### DIFF
--- a/src/main/kotlin/org/wfanet/measurement/consent/client/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/common/BUILD.bazel
@@ -33,5 +33,5 @@ kt_jvm_library(
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signatures",
-    ]
+    ],
 )

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/common/BUILD.bazel
@@ -25,3 +25,13 @@ kt_jvm_library(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signing_key_storage",
     ],
 )
+
+kt_jvm_library(
+    name = "veify_signed_data",
+    srcs = ["VerifySignedData.kt"],
+    deps = [
+        "//src/main/proto/wfa/measurement/api/v2alpha:crypto_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/crypto:signatures",
+    ]
+)

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/common/VerifySignedData.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/common/VerifySignedData.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wfanet.measurement.consent.client.common
+
+import java.security.cert.X509Certificate
+import org.wfanet.measurement.api.v2alpha.SignedData
+import org.wfanet.measurement.common.crypto.verifySignature
+
+/** Verify the [signedData.data] against [signedData.signature] */
+fun X509Certificate.verifySignedData(signedData: SignedData): Boolean {
+  return verifySignature(signedData.data, signedData.signature)
+}

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/BUILD.bazel
@@ -8,6 +8,7 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/consent/client/common:key_handles",
         "//src/main/kotlin/org/wfanet/measurement/consent/client/common:signing",
+        "//src/main/kotlin/org/wfanet/measurement/consent/client/common:veify_signed_data",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_spec_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:requisition_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
@@ -23,6 +23,7 @@ import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.common.crypto.PrivateKeyHandle
 import org.wfanet.measurement.common.crypto.hashSha256
 import org.wfanet.measurement.common.crypto.verifySignature
+import org.wfanet.measurement.consent.client.common.verifySignedData
 
 /** Computes the "requisition fingerprint" for [requisition]. */
 fun computeRequisitionFingerprint(requisition: Requisition): ByteString {
@@ -33,18 +34,15 @@ fun computeRequisitionFingerprint(requisition: Requisition): ByteString {
 
 /**
  * Verify the MeasurementSpec from the MeasurementConsumer
- * 1. Verifies the [measurementSpec] against the [measurementSpecSignature]
- * 2. TODO: Check for replay attacks for [measurementSpecSignature]
+ * 1. Verifies the [signedMeasurementSpec.data] against the [signedMeasurementSpec.signature]
+ * 2. TODO: Check for replay attacks for [signedMeasurementSpec.signature]
  * 3. TODO: Verify certificate chain for [measurementConsumerCertificate]
  */
 fun verifyMeasurementSpec(
   signedMeasurementSpec: SignedData,
   measurementConsumerCertificate: X509Certificate
 ): Boolean {
-  return measurementConsumerCertificate.verifySignature(
-    signedMeasurementSpec.data,
-    signedMeasurementSpec.signature
-  )
+  return measurementConsumerCertificate.verifySignedData(signedMeasurementSpec)
 }
 
 /**
@@ -69,7 +67,7 @@ fun decryptRequisitionSpec(
  * The steps are:
  * 1. TODO: Check for replay attacks
  * 2. TODO: Verify certificate chain for [measurementConsumerCertificate]
- * 3. Verify the [requisitionSpecSignature]
+ * 3. Verify the [signedRequisitionSpec.signature]
  * 4. Compare the measurement encryption key to the one in [measurementSpec]
  * 5. Compute the hash of the nonce and verify that the list in [measurementSpec] contains it
  */
@@ -79,17 +77,14 @@ fun verifyRequisitionSpec(
   measurementSpec: MeasurementSpec,
   measurementConsumerCertificate: X509Certificate
 ): Boolean {
-  return measurementConsumerCertificate.verifySignature(
-    signedRequisitionSpec.data,
-    signedRequisitionSpec.signature
-  ) &&
+  return measurementConsumerCertificate.verifySignedData(signedRequisitionSpec) &&
     requisitionSpec.measurementPublicKey.equals(measurementSpec.measurementPublicKey) &&
     measurementSpec.nonceHashesList.contains(hashSha256(requisitionSpec.nonce))
 }
 
 /**
  * Verify the [elGamalPublicKeySignature] from another duchy.
- * 1. Verifies the [elGamalPublicKey] against the [elGamalPublicKeySignature]
+ * 1. Verifies the [elGamalPublicKeyData] against the [elGamalPublicKeySignature]
  * 2. TODO: Check for replay attacks for [elGamalPublicKeySignature]
  * 3. TODO: Verify certificate chain for [duchyCertificate]
  */

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClient.kt
@@ -16,7 +16,6 @@ package org.wfanet.measurement.consent.client.dataprovider
 
 import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
-import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.MeasurementSpec
 import org.wfanet.measurement.api.v2alpha.Requisition
 import org.wfanet.measurement.api.v2alpha.RequisitionSpec
@@ -39,13 +38,12 @@ fun computeRequisitionFingerprint(requisition: Requisition): ByteString {
  * 3. TODO: Verify certificate chain for [measurementConsumerCertificate]
  */
 fun verifyMeasurementSpec(
-  measurementSpecSignature: ByteString,
-  measurementSpec: MeasurementSpec,
+  signedMeasurementSpec: SignedData,
   measurementConsumerCertificate: X509Certificate
 ): Boolean {
   return measurementConsumerCertificate.verifySignature(
-    measurementSpec.toByteString(),
-    measurementSpecSignature
+    signedMeasurementSpec.data,
+    signedMeasurementSpec.signature
   )
 }
 
@@ -76,14 +74,14 @@ fun decryptRequisitionSpec(
  * 5. Compute the hash of the nonce and verify that the list in [measurementSpec] contains it
  */
 fun verifyRequisitionSpec(
-  requisitionSpecSignature: ByteString,
+  signedRequisitionSpec: SignedData,
   requisitionSpec: RequisitionSpec,
   measurementSpec: MeasurementSpec,
   measurementConsumerCertificate: X509Certificate
 ): Boolean {
   return measurementConsumerCertificate.verifySignature(
-    requisitionSpec.toByteString(),
-    requisitionSpecSignature
+    signedRequisitionSpec.data,
+    signedRequisitionSpec.signature
   ) &&
     requisitionSpec.measurementPublicKey.equals(measurementSpec.measurementPublicKey) &&
     measurementSpec.nonceHashesList.contains(hashSha256(requisitionSpec.nonce))
@@ -96,12 +94,9 @@ fun verifyRequisitionSpec(
  * 3. TODO: Verify certificate chain for [duchyCertificate]
  */
 fun verifyElGamalPublicKey(
+  elGamalPublicKeyData: ByteString,
   elGamalPublicKeySignature: ByteString,
-  elGamalPublicKey: ElGamalPublicKey,
   duchyCertificate: X509Certificate
 ): Boolean {
-  return duchyCertificate.verifySignature(
-    elGamalPublicKey.toByteString(),
-    elGamalPublicKeySignature
-  )
+  return duchyCertificate.verifySignature(elGamalPublicKeyData, elGamalPublicKeySignature)
 }

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/BUILD.bazel
@@ -8,6 +8,7 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/consent/client/common:key_handles",
         "//src/main/kotlin/org/wfanet/measurement/consent/client/common:signing",
+        "//src/main/kotlin/org/wfanet/measurement/consent/client/common:veify_signed_data",
         "//src/main/proto/wfa/measurement/api/v2alpha:certificate_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClient.kt
@@ -102,7 +102,7 @@ fun signElgamalPublicKey(
 
 /**
  * Verify the [elGamalPublicKeySignature] from another duchy.
- * 1. Verifies the [elGamalPublicKey] against the [elGamalPublicKeySignature]
+ * 1. Verifies the [elGamalPublicKeyData] against the [elGamalPublicKeySignature]
  * 2. TODO: Check for replay attacks for [elGamalPublicKeySignature]
  * 3. TODO: Verify certificate chain for [duchyCertificate]
  */

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClient.kt
@@ -107,12 +107,9 @@ fun signElgamalPublicKey(
  * 3. TODO: Verify certificate chain for [duchyCertificate]
  */
 fun verifyElGamalPublicKey(
+  elGamalPublicKeyData: ByteString,
   elGamalPublicKeySignature: ByteString,
-  elGamalPublicKey: ElGamalPublicKey,
   duchyCertificate: X509Certificate
 ): Boolean {
-  return duchyCertificate.verifySignature(
-    elGamalPublicKey.toByteString(),
-    elGamalPublicKeySignature
-  )
+  return duchyCertificate.verifySignature(elGamalPublicKeyData, elGamalPublicKeySignature)
 }

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/kingdom/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/kingdom/BUILD.bazel
@@ -6,6 +6,7 @@ kt_jvm_library(
     name = "kingdom",
     srcs = ["KingdomClient.kt"],
     deps = [
+        "//src/main/kotlin/org/wfanet/measurement/consent/client/common:veify_signed_data",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_spec_kt_jvm_proto",
         "@wfa_common_jvm//imports/java/com/google/protobuf",

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/kingdom/KingdomClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/kingdom/KingdomClient.kt
@@ -14,9 +14,8 @@
 
 package org.wfanet.measurement.consent.client.kingdom
 
-import com.google.protobuf.ByteString
 import java.security.cert.X509Certificate
-import org.wfanet.measurement.api.v2alpha.MeasurementSpec
+import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.common.crypto.verifySignature
 
 /**
@@ -26,12 +25,11 @@ import org.wfanet.measurement.common.crypto.verifySignature
  * 3. TODO: Verify certificate chain for [measurementConsumerCertificate]
  */
 fun verifyMeasurementSpec(
-  measurementSpecSignature: ByteString,
-  measurementSpec: MeasurementSpec,
+  signedMeasurementSpec: SignedData,
   measurementConsumerCertificate: X509Certificate
 ): Boolean {
   return measurementConsumerCertificate.verifySignature(
-    measurementSpec.toByteString(),
-    measurementSpecSignature
+    signedMeasurementSpec.data,
+    signedMeasurementSpec.signature
   )
 }

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/kingdom/KingdomClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/kingdom/KingdomClient.kt
@@ -16,20 +16,17 @@ package org.wfanet.measurement.consent.client.kingdom
 
 import java.security.cert.X509Certificate
 import org.wfanet.measurement.api.v2alpha.SignedData
-import org.wfanet.measurement.common.crypto.verifySignature
+import org.wfanet.measurement.consent.client.common.verifySignedData
 
 /**
  * Verify the MeasurementSpec from the MeasurementConsumer
- * 1. Verifies the [measurementSpec] against the [measurementSpecSignature]
- * 2. TODO: Check for replay attacks for [measurementSpecSignature]
+ * 1. Verifies the [signedMeasurementSpec.data] against the [signedMeasurementSpec.signature]
+ * 2. TODO: Check for replay attacks for [signedMeasurementSpec.signature]
  * 3. TODO: Verify certificate chain for [measurementConsumerCertificate]
  */
 fun verifyMeasurementSpec(
   signedMeasurementSpec: SignedData,
   measurementConsumerCertificate: X509Certificate
 ): Boolean {
-  return measurementConsumerCertificate.verifySignature(
-    signedMeasurementSpec.data,
-    signedMeasurementSpec.signature
-  )
+  return measurementConsumerCertificate.verifySignedData(signedMeasurementSpec)
 }

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/BUILD.bazel
@@ -8,6 +8,7 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/measurement/consent/client/common:key_handles",
         "//src/main/kotlin/org/wfanet/measurement/consent/client/common:signing",
+        "//src/main/kotlin/org/wfanet/measurement/consent/client/common:veify_signed_data",
         "//src/main/proto/wfa/measurement/api/v2alpha:crypto_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_kt_jvm_proto",
         "//src/main/proto/wfa/measurement/api/v2alpha:measurement_spec_kt_jvm_proto",

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -101,12 +101,8 @@ fun decryptResult(
  * 2. TODO: Check for replay attacks for [resultSignature]
  * 3. TODO: Verify certificate chain for [aggregatorCertificate]
  */
-fun verifyResult(
-  resultSignature: ByteString,
-  measurementResult: MeasurementResult,
-  aggregatorCertificate: X509Certificate
-): Boolean {
-  return aggregatorCertificate.verifySignature(measurementResult.toByteString(), resultSignature)
+fun verifyResult(signedResult: SignedData, aggregatorCertificate: X509Certificate): Boolean {
+  return aggregatorCertificate.verifySignature(signedResult.data, signedResult.signature)
 }
 
 /**
@@ -116,12 +112,11 @@ fun verifyResult(
  * 3. TODO: Verify certificate chain for [edpCertificate]
  */
 fun verifyEncryptionPublicKey(
-  encryptionPublicKeySignature: ByteString,
-  encryptionPublicKey: EncryptionPublicKey,
+  signedEncryptionPublicKey: SignedData,
   edpCertificate: X509Certificate
 ): Boolean {
   return edpCertificate.verifySignature(
-    encryptionPublicKey.toByteString(),
-    encryptionPublicKeySignature
+    signedEncryptionPublicKey.data,
+    signedEncryptionPublicKey.signature,
   )
 }

--- a/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
+++ b/src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClient.kt
@@ -27,6 +27,7 @@ import org.wfanet.measurement.common.crypto.hashSha256
 import org.wfanet.measurement.common.crypto.verifySignature
 import org.wfanet.measurement.consent.client.common.signMessage
 import org.wfanet.measurement.consent.client.common.toPublicKeyHandle
+import org.wfanet.measurement.consent.client.common.verifySignedData
 
 /** Create a SHA256 hash of the serialized [dataProviderList] using the [dataProviderListSalt]. */
 fun createDataProviderListHash(
@@ -97,8 +98,8 @@ fun decryptResult(
 
 /**
  * Verify the Result from the Aggregator
- * 1. Verifies the [measurementResult] against the [resultSignature]
- * 2. TODO: Check for replay attacks for [resultSignature]
+ * 1. Verifies the [signedResult.data] against the [signedResult.signature]
+ * 2. TODO: Check for replay attacks for [signedResult.signature]
  * 3. TODO: Verify certificate chain for [aggregatorCertificate]
  */
 fun verifyResult(signedResult: SignedData, aggregatorCertificate: X509Certificate): Boolean {
@@ -107,7 +108,8 @@ fun verifyResult(signedResult: SignedData, aggregatorCertificate: X509Certificat
 
 /**
  * Verify the EncryptionPublicKey from the Endpoint Data Provider
- * 1. Verifies the [encryptionPublicKey] against the [encryptionPublicKeySignature]
+ * 1. Verifies the [signedEncryptionPublicKey.data] against the
+ * [signedEncryptionPublicKey.signature]
  * 2. TODO: Check for replay attacks for [encryptionPublicKeySignature]
  * 3. TODO: Verify certificate chain for [edpCertificate]
  */
@@ -115,8 +117,5 @@ fun verifyEncryptionPublicKey(
   signedEncryptionPublicKey: SignedData,
   edpCertificate: X509Certificate
 ): Boolean {
-  return edpCertificate.verifySignature(
-    signedEncryptionPublicKey.data,
-    signedEncryptionPublicKey.signature,
-  )
+  return edpCertificate.verifySignedData(signedEncryptionPublicKey)
 }

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/dataprovider/DataProviderClientTest.kt
@@ -67,8 +67,7 @@ class DataProviderClientTest {
 
     assertThat(
         verifyMeasurementSpec(
-          measurementSpecSignature = signedMeasurementSpec.signature,
-          measurementSpec = FAKE_MEASUREMENT_SPEC,
+          signedMeasurementSpec = signedMeasurementSpec,
           measurementConsumerCertificate = signingKeyHandle.certificate,
         )
       )
@@ -94,7 +93,7 @@ class DataProviderClientTest {
     assertThat(signedRequisitionSpec).isEqualTo(decryptedSignedDataRequisitionSpec)
     assertThat(
         verifyRequisitionSpec(
-          requisitionSpecSignature = decryptedSignedDataRequisitionSpec.signature,
+          signedRequisitionSpec = signedRequisitionSpec,
           requisitionSpec = decryptedRequisitionSpec,
           measurementConsumerCertificate = MC_SIGNING_KEY.certificate,
           measurementSpec = FAKE_MEASUREMENT_SPEC,
@@ -109,7 +108,7 @@ class DataProviderClientTest {
 
     assertThat(
         verifyRequisitionSpec(
-          requisitionSpecSignature = signedRequisitionSpec.signature,
+          signedRequisitionSpec = signedRequisitionSpec,
           requisitionSpec = FAKE_REQUISITION_SPEC,
           measurementConsumerCertificate = MC_SIGNING_KEY.certificate,
           measurementSpec = FAKE_MEASUREMENT_SPEC,
@@ -125,8 +124,8 @@ class DataProviderClientTest {
 
     assertThat(
         verifyElGamalPublicKey(
+          elGamalPublicKeyData = signedElGamalPublicKey.data,
           elGamalPublicKeySignature = signedElGamalPublicKey.signature,
-          elGamalPublicKey = FAKE_EL_GAMAL_PUBLIC_KEY,
           duchyCertificate = signingKeyHandle.certificate,
         )
       )

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClientTest.kt
@@ -22,8 +22,8 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResult
 import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
+import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResult
 import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.api.v2alpha.copy
 import org.wfanet.measurement.api.v2alpha.measurementSpec
@@ -204,12 +204,12 @@ class DuchyClientTest {
     val signedElGamalPublicKey: SignedData = signMessage(FAKE_EL_GAMAL_PUBLIC_KEY, signingKeyHandle)
 
     assertThat(
-      org.wfanet.measurement.consent.client.dataprovider.verifyElGamalPublicKey(
-        elGamalPublicKeyData = signedElGamalPublicKey.data,
-        elGamalPublicKeySignature = signedElGamalPublicKey.signature,
-        duchyCertificate = signingKeyHandle.certificate,
+        org.wfanet.measurement.consent.client.dataprovider.verifyElGamalPublicKey(
+          elGamalPublicKeyData = signedElGamalPublicKey.data,
+          elGamalPublicKeySignature = signedElGamalPublicKey.signature,
+          duchyCertificate = signingKeyHandle.certificate,
+        )
       )
-    )
       .isTrue()
   }
 

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/duchy/DuchyClientTest.kt
@@ -23,6 +23,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.api.v2alpha.Measurement.Result as MeasurementResult
+import org.wfanet.measurement.api.v2alpha.ElGamalPublicKey
 import org.wfanet.measurement.api.v2alpha.SignedData
 import org.wfanet.measurement.api.v2alpha.copy
 import org.wfanet.measurement.api.v2alpha.measurementSpec
@@ -32,8 +33,11 @@ import org.wfanet.measurement.common.HexString
 import org.wfanet.measurement.common.crypto.hashSha256
 import org.wfanet.measurement.common.crypto.tink.TinkPrivateKeyHandle
 import org.wfanet.measurement.common.crypto.verifySignature
+import org.wfanet.measurement.consent.client.common.signMessage
 import org.wfanet.measurement.consent.client.common.toEncryptionPublicKey
 import org.wfanet.measurement.consent.client.dataprovider.computeRequisitionFingerprint
+import org.wfanet.measurement.consent.testing.DUCHY_1_NON_AGG_CERT_PEM_FILE
+import org.wfanet.measurement.consent.testing.DUCHY_1_NON_AGG_KEY_FILE
 import org.wfanet.measurement.consent.testing.DUCHY_AGG_CERT_PEM_FILE
 import org.wfanet.measurement.consent.testing.DUCHY_AGG_KEY_FILE
 import org.wfanet.measurement.consent.testing.readSigningKeyHandle
@@ -46,6 +50,8 @@ private val NONCE_2_HASH =
   HexString("45FEAA185D434E0EB4747F547F0918AA5B8403DBBD7F90D6F0D8C536E2D620D7")
 
 private val MEASUREMENT_SPEC = measurementSpec { nonceHashes += NONCE_HASH.bytes }
+
+private val FAKE_EL_GAMAL_PUBLIC_KEY = ElGamalPublicKey.getDefaultInstance()
 
 @RunWith(JUnit4::class)
 class DuchyClientTest {
@@ -192,8 +198,26 @@ class DuchyClientTest {
     assertThat(decryptedSignedResult).isEqualTo(signedMeasurementResult)
   }
 
+  @Test
+  fun `verifiesElgamalPublicKey verifies valid EncryptionPublicKey signature`() = runBlocking {
+    val signingKeyHandle = DUCHY_SIGNING_KEY
+    val signedElGamalPublicKey: SignedData = signMessage(FAKE_EL_GAMAL_PUBLIC_KEY, signingKeyHandle)
+
+    assertThat(
+      org.wfanet.measurement.consent.client.dataprovider.verifyElGamalPublicKey(
+        elGamalPublicKeyData = signedElGamalPublicKey.data,
+        elGamalPublicKeySignature = signedElGamalPublicKey.signature,
+        duchyCertificate = signingKeyHandle.certificate,
+      )
+    )
+      .isTrue()
+  }
+
   companion object {
     private val AGGREGATOR_SIGNING_KEY =
       readSigningKeyHandle(DUCHY_AGG_CERT_PEM_FILE, DUCHY_AGG_KEY_FILE)
+
+    private val DUCHY_SIGNING_KEY =
+      readSigningKeyHandle(DUCHY_1_NON_AGG_CERT_PEM_FILE, DUCHY_1_NON_AGG_KEY_FILE)
   }
 }

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/kingdom/KingdomClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/kingdom/KingdomClientTest.kt
@@ -47,9 +47,8 @@ class KingdomClientTest {
 
     assertTrue(
       verifyMeasurementSpec(
-        measurementSpecSignature = signedMeasurementSpec.signature,
-        measurementSpec = FAKE_MEASUREMENT_SPEC,
-        measurementConsumerCertificate = MC_SIGNING_KEY.certificate,
+        signedMeasurementSpec = signedMeasurementSpec,
+        measurementConsumerCertificate = MC_SIGNING_KEY.certificate
       )
     )
   }

--- a/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
+++ b/src/test/kotlin/org/wfanet/measurement/consent/client/measurementconsumer/MeasurementConsumerClientTest.kt
@@ -165,8 +165,7 @@ class MeasurementConsumerClientTest {
     assertThat(signedResult).isEqualTo(decryptedSignedDataResult)
     assertThat(
         verifyResult(
-          resultSignature = decryptedSignedDataResult.signature,
-          measurementResult = decryptedResult,
+          signedResult = signedResult,
           aggregatorCertificate = AGGREGATOR_SIGNING_KEY.certificate,
         )
       )
@@ -181,8 +180,7 @@ class MeasurementConsumerClientTest {
 
     assertThat(
         verifyResult(
-          resultSignature = signedResult.signature,
-          measurementResult = FAKE_MEASUREMENT_RESULT,
+          signedResult = signedResult,
           aggregatorCertificate = signingKeyHandle.certificate,
         )
       )
@@ -197,8 +195,7 @@ class MeasurementConsumerClientTest {
 
     assertThat(
         verifyEncryptionPublicKey(
-          encryptionPublicKeySignature = signedEncryptionPublicKey.signature,
-          encryptionPublicKey = FAKE_ENCRYPTION_PUBLIC_KEY,
+          signedEncryptionPublicKey = signedEncryptionPublicKey,
           edpCertificate = signingKeyHandle.certificate,
         )
       )


### PR DESCRIPTION
Verification functions now take the signed data instead of the proto object to avoid non-deterministic conversion.
Related issue: https://github.com/world-federation-of-advertisers/consent-signaling-client/issues/37

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/consent-signaling-client/38)
<!-- Reviewable:end -->
